### PR TITLE
Remove ECO chain support

### DIFF
--- a/build/skeleton/node.sh
+++ b/build/skeleton/node.sh
@@ -578,8 +578,6 @@ chain_prepare_stage()
        [ "$CHAIN_NAME" != "esc-oracle" ] && \
        [ "$CHAIN_NAME" != "eid" ] && \
        [ "$CHAIN_NAME" != "eid-oracle" ] && \
-       [ "$CHAIN_NAME" != "eco" ] && \
-       [ "$CHAIN_NAME" != "eco-oracle" ] && \
        [ "$CHAIN_NAME" != "pgp" ] && \
        [ "$CHAIN_NAME" != "pgp-oracle" ] && \
        [ "$CHAIN_NAME" != "pg" ] && \
@@ -598,7 +596,6 @@ chain_prepare_stage()
     if [ "$CHAIN_NAME" == "ela" ] || \
        [ "$CHAIN_NAME" == "esc" ] || \
        [ "$CHAIN_NAME" == "eid" ] || \
-       [ "$CHAIN_NAME" == "eco" ] || \
        [ "$CHAIN_NAME" == "pgp" ] || \
        [ "$CHAIN_NAME" == "pg" ] || \
        [ "$CHAIN_NAME" == "arbiter" ]; then
@@ -610,7 +607,6 @@ chain_prepare_stage()
             local RELEASE_PLATFORM=nosupport
         fi
     elif [ "$CHAIN_NAME" == "esc-oracle" ] || \
-         [ "$CHAIN_NAME" == "eco-oracle" ] || \
          [ "$CHAIN_NAME" == "pgp-oracle" ] || \
          [ "$CHAIN_NAME" == "pg-oracle" ] || \
          [ "$CHAIN_NAME" == "eid-oracle" ]; then
@@ -659,7 +655,6 @@ chain_prepare_stage()
     fi
 
     if [ "$CHAIN_NAME" == "esc-oracle" ] || \
-       [ "$CHAIN_NAME" == "eco-oracle" ] || \
        [ "$CHAIN_NAME" == "pgp-oracle" ] || \
        [ "$CHAIN_NAME" == "pg-oracle" ] || \
        [ "$CHAIN_NAME" == "eid-oracle" ] ; then
@@ -711,8 +706,6 @@ all_start()
     esc-oracle_installed && esc-oracle_start
     eid_installed        && eid_start
     eid-oracle_installed && eid-oracle_start
-    eco_installed        && eco_start
-    eco-oracle_installed && eco-oracle_start
     #pgp_installed        && pgp_start
     #pgp-oracle_installed && pgp-oracle_start
     pg_installed         && pg_start
@@ -728,12 +721,10 @@ all_stop()
     eid_installed        && eid_stop
     esc-oracle_installed && esc-oracle_stop
     esc_installed        && esc_stop
-    eco-oracle_installed && eco-oracle_stop
     #pgp_installed        && pgp_stop
     #pgp-oracle_installed && pgp-oracle_stop
     pg_installed         && pg_stop
     pg-oracle_installed  && pg-oracle_stop
-    eco_installed        && eco_stop
 }
 
 all_status()
@@ -743,8 +734,6 @@ all_status()
     esc-oracle_installed && esc-oracle_status
     eid_installed        && eid_status
     eid-oracle_installed && eid-oracle_status
-    eco_installed        && eco_status
-    eco-oracle_installed && eco-oracle_status
     #pgp_installed        && pgp_status
     #pgp-oracle_installed && pgp-oracle_status
     pg_installed         && pg_status
@@ -759,8 +748,6 @@ all_update()
     esc-oracle_installed && esc-oracle_update
     eid_installed        && eid_update
     eid-oracle_installed && eid-oracle_update
-    eco_installed        && eco_update
-    eco-oracle_installed && eco-oracle_update
     #pgp_installed        && pgp_update
     #pgp-oracle_installed && pgp-oracle_update
     pg_installed         && pg_update
@@ -775,8 +762,6 @@ all_init()
     esc-oracle_init
     eid_init
     eid-oracle_init
-    eco_init
-    eco-oracle_init
     #pgp_init
     #pgp-oracle_init
     pg_init
@@ -791,8 +776,6 @@ all_compress_log()
     esc-oracle_installed && esc-oracle_compress_log
     eid_installed        && eid_compress_log
     eid-oracle_installed && eid-oracle_compress_log
-    eco_installed        && eco_compress_log
-    eco-oracle_installed && eco-oracle_compress_log
     #pgp_installed        && pgp_compress_log
     #pgp-oracle_installed && pgp-oracle_compress_log
     pg_installed         && pg_compress_log
@@ -807,8 +790,6 @@ all_remove_log()
     esc-oracle_installed && esc-oracle_remove_log
     eid_installed        && eid_remove_log
     eid-oracle_installed && eid-oracle_remove_log
-    eco_installed        && eco_remove_log
-    eco-oracle_installed && eco-oracle_remove_log
     #pgp_installed        && pgp_remove_log
     #pgp-oracle_installed && pgp-oracle_remove_log
     pg_installed         && pg_remove_log
@@ -2187,77 +2168,6 @@ esc_start()
     esc_status
 }
 
-eco_start()
-{
-    if [ ! -f $SCRIPT_PATH/eco/eco ]; then
-        echo_error "$SCRIPT_PATH/eco/eco is not exist"
-        return
-    fi
-
-    if [ "$CHAIN_TYPE" == "mainnet" ]; then
-        local ECO_OPTS=
-    elif [ "$CHAIN_TYPE" == "testnet" ]; then
-        local ECO_OPTS=--testnet
-    else
-        echo_error "do not support $CHAIN_TYPE"
-        return
-    fi
-
-    local PID=$(pgrep -f '^\./eco .*--rpc ')
-    if [ "$PID" != "" ]; then
-        eco_status
-        return
-    fi
-
-    echo "Starting eco..."
-    cd $SCRIPT_PATH/eco
-    mkdir -p $SCRIPT_PATH/eco/logs/
-
-    if [ -f ~/.config/elastos/eco.txt ]; then
-        if [ -f $SCRIPT_PATH/eco/data/miner_address.txt ]; then
-            local ECO_OPTS="$ECO_OPTS --pbft.miner.address $SCRIPT_PATH/eco/data/miner_address.txt"
-        fi
-        nohup $SHELL -c "./eco \
-            $ECO_OPTS \
-            --allow-insecure-unlock \
-            --datadir $SCRIPT_PATH/eco/data \
-            --mine \
-            --miner.threads 1 \
-            --password ~/.config/elastos/eco.txt \
-            --pbft.keystore ${SCRIPT_PATH}/ela/keystore.dat \
-            --pbft.keystore.password ~/.config/elastos/ela.txt \
-            --pbft.net.address '$(extip)' \
-            --pbft.net.port 20659 \
-            --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'db,eth,net,pbft,personal,txpool,web3' \
-            --rpcvhosts '*' \
-            --syncmode full \
-            --unlock '0x$(cat $SCRIPT_PATH/eco/data/keystore/UTC* | jq -r .address)' \
-            --ws \
-            --wsaddr '0.0.0.0' \
-            --wsorigins '*' \
-            2>&1 \
-            | rotatelogs $SCRIPT_PATH/eco/logs/eco-%Y-%m-%d-%H_%M_%S.log 20M" &
-    else
-        nohup $SHELL -c "./eco \
-            $ECO_OPTS \
-            --datadir $SCRIPT_PATH/eco/data \
-            --lightserv 10 \
-            --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'admin,eth,net,txpool,web3' \
-            --rpcvhosts '*' \
-            --ws \
-            --wsaddr '0.0.0.0' \
-            --wsorigins '*' \
-            2>&1 \
-            | rotatelogs $SCRIPT_PATH/eco/logs/eco-%Y-%m-%d-%H_%M_%S.log 20M" &
-    fi
-
-    sleep 3
-    eco_status
-}
 
 pgp_start()
 {
@@ -2419,21 +2329,6 @@ esc_stop()
     sync
     esc_status
 }
-eco_stop()
-{
-    local PID=$(pgrep -f '^\./eco .*--rpc ')
-    if [ "$PID" != "" ]; then
-        echo "Stopping eco..."
-        kill -s SIGINT $PID
-        while ps -p $PID 1>/dev/null; do
-            echo -n .
-            sleep 1
-        done
-        echo
-    fi
-    sync
-    eco_status
-}
 
 pgp_stop()
 {
@@ -2476,14 +2371,6 @@ esc_installed()
     fi
 }
 
-eco_installed()
-{
-    if [ -f $SCRIPT_PATH/eco/eco ]; then
-        true
-    else
-        false
-    fi
-}
 
 pgp_installed()
 {
@@ -2512,14 +2399,6 @@ esc_ver()
     fi
 }
 
-eco_ver()
-{
-    if [ -f $SCRIPT_PATH/eco/eco ]; then
-        echo "eco $($SCRIPT_PATH/eco/eco version | grep 'Git Commit:' | sed 's/.* //' | cut -c1-7)"
-    else
-        echo "eco N/A"
-    fi
-}
 
 pgp_ver()
 {
@@ -2557,23 +2436,6 @@ esc_client()
     fi
 }
 
-eco_client()
-{
-    if [ ! -f $SCRIPT_PATH/eco/eco ]; then
-        echo_error "$SCRIPT_PATH/eco/eco is not exist"
-        return
-    fi
-
-    cd $SCRIPT_PATH/eco
-    if [ "$1" == "" ]; then
-        ./eco --datadir $SCRIPT_PATH/eco/data --help
-    elif [ "$1" == "attach" ] &&
-         [ ! -S $SCRIPT_PATH/eco/data/geth.ipc ]; then
-        return
-    else
-        ./eco --datadir $SCRIPT_PATH/eco/data --nousb $*
-    fi
-}
 
 pgp_client()
 {
@@ -2627,21 +2489,6 @@ esc_jsonrpc()
         http://127.0.0.1:20636 | jq .
 }
 
-eco_jsonrpc()
-{
-    if [ "$1" == "" ]; then
-        return
-    fi
-
-    if [[ $1 =~ ^[_3a-zA-Z]+$ ]] && [ "$2" == "" ]; then
-        local DATA="{\"method\":\"$1\",\"id\":0}"
-    else
-        local DATA=$1
-    fi
-
-    curl -s -H 'Content-Type:application/json' -X POST --data $DATA \
-        http://127.0.0.1:20656 | jq .
-}
 
 pgp_jsonrpc()
 {
@@ -2755,85 +2602,6 @@ esc_status()
     echo
 }
 
-eco_status()
-{
-    local ECO_VER=$(eco_ver)
-
-    local ECO_DISK_USAGE=$(disk_usage $SCRIPT_PATH/eco)
-
-    if [ -f ~/.config/elastos/eco.txt ]; then
-        cd $SCRIPT_PATH/eco
-        local ECO_KEYSTORE=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
-            --nousb --verbosity 0 account list | sed -n '1 s/.*keystore:\/\///p')
-        if [ $ECO_KEYSTORE ] && [ -f $ECO_KEYSTORE ]; then
-            local ECO_ADDRESS=0x$(cat $ECO_KEYSTORE | jq -r .address)
-        else
-            local ECO_ADDRESS=N/A
-        fi
-    else
-        local ECO_ADDRESS=N/A
-    fi
-
-    local ECO_MINER_ADDRESS=$(cat $SCRIPT_PATH/eco/data/miner_address.txt 2>/dev/null)
-    if [ "$ECO_MINER_ADDRESS" == "" ]; then
-        local ECO_MINER_ADDRESS=$ECO_ADDRESS
-    fi
-
-    local PID=$(pgrep -f '^\./eco .*--rpc ')
-    if [ "$PID" == "" ]; then
-        status_head $ECO_VER  Stopped
-        status_info "Disk"    "$ECO_DISK_USAGE"
-        status_info "Address" "$ECO_ADDRESS"
-        echo
-        return
-    fi
-
-    local ECO_RAM=$(mem_usage $PID)
-    local ECO_UPTIME=$(run_time $PID)
-    local ECO_NUM_TCPS=$(num_tcps $PID)
-    local ECO_TCP_LISTEN=$(list_tcp $PID)
-    local ECO_UDP_LISTEN=$(list_udp $PID)
-    local ECO_NUM_FILES=$(num_files $PID)
-
-    local ECO_NUM_PEERS=$(eco_jsonrpc \
-        '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
-        | jq -r '.result')
-    ECO_NUM_PEERS=$(($ECO_NUM_PEERS))
-    if [[ ! "$ECO_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        ECO_NUM_PEERS=0
-    fi
-    local ECO_HEIGHT=$(eco_jsonrpc \
-        '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-        | jq -r '.result')
-    ECO_HEIGHT=$(($ECO_HEIGHT))
-    if [[ ! "$ECO_HEIGHT" =~ ^[0-9]+$ ]]; then
-        ECO_HEIGHT=N/A
-    fi
-
-    local ECO_BALANCE=$(eco_client \
-        attach --exec "web3.fromWei(eth.getBalance('$ECO_ADDRESS'),'ether')")
-    if [ "$ECO_BALANCE" == "" ]; then
-        ECO_BALANCE=N/A
-    elif [[ $ECO_BALANCE =~ [^.0-9e-] ]]; then
-        ECO_BALANCE=N/A
-    fi
-
-    status_head $ECO_VER Running
-    status_info "Disk"      "$ECO_DISK_USAGE"
-    status_info "Address"   "$ECO_ADDRESS"
-    status_info "Balance"   "$ECO_BALANCE"
-    status_info "Miner"     "$ECO_MINER_ADDRESS"
-    status_info "PID"       "$PID"
-    status_info "RAM"       "$ECO_RAM"
-    status_info "Uptime"    "$ECO_UPTIME"
-    status_info "#Files"    "$ECO_NUM_FILES"
-    status_info "TCP Ports" "$ECO_TCP_LISTEN"
-    status_info "#TCP"      "$ECO_NUM_TCPS"
-    status_info "UDP Ports" "$ECO_UDP_LISTEN"
-    status_info "#Peers"    "$ECO_NUM_PEERS"
-    status_info "Height"    "$ECO_HEIGHT"
-    echo
-}
 
 
 pgp_status()
@@ -3011,12 +2779,6 @@ esc_remove_log()
 }
 
 
-eco_compress_log()
-{
-    compress_log $SCRIPT_PATH/eco/data/eco/logs/dpos
-    compress_log $SCRIPT_PATH/eco/data/logs-spv
-    compress_log $SCRIPT_PATH/eco/logs
-}
 
 
 pgp_compress_log()
@@ -3033,12 +2795,6 @@ pg_compress_log()
     compress_log $SCRIPT_PATH/pg/logs
 }
 
-eco_remove_log()
-{
-    remove_log $SCRIPT_PATH/eco/data/eco/logs/dpos
-    remove_log $SCRIPT_PATH/eco/data/logs-spv
-    remove_log $SCRIPT_PATH/eco/logs
-}
 
 pgp_remove_log()
 {
@@ -3090,40 +2846,6 @@ esc_update()
     fi
 }
 
-eco_update()
-{
-    unset OPTIND
-    while getopts "ny" OPTION; do
-        case $OPTION in
-            n)
-                local NO_START_AFTER_UPDATE=1
-                ;;
-            y)
-                local YES_TO_ALL=1
-                ;;
-        esac
-    done
-
-    chain_prepare_stage eco eco
-    if [ "$?" != "0" ]; then
-        return
-    fi
-
-    local PATH_STAGE=$SCRIPT_PATH/.node-upload/eco
-    local DIR_DEPLOY=$SCRIPT_PATH/eco
-
-    local PID=$(pgrep -f '^\./eco .*--rpc ')
-    if [ $PID ]; then
-        eco_stop
-    fi
-
-    mkdir -p $DIR_DEPLOY
-    cp -v $PATH_STAGE/eco $DIR_DEPLOY/
-
-    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
-        eco_start
-    fi
-}
 
 pgp_update()
 {
@@ -3272,84 +2994,6 @@ esc_init()
 
     touch ${SCRIPT_PATH}/esc/.init
     echo_ok "esc initialized"
-    echo
-}
-eco_init()
-{
-    if [ $(mem_free) -lt 512 ]; then
-        echo_error "free memory not enough"
-        return
-    fi
-
-    local ECO_KEYSTORE=
-    local ECO_KEYSTORE_PASS_FILE=~/.config/elastos/eco.txt
-
-    if [ ! -f ${SCRIPT_PATH}/eco/eco ]; then
-        eco_update -y
-    fi
-
-    if [ -f $SCRIPT_PATH/eco/.init ]; then
-        echo_error "eco has already been initialized"
-        return
-    fi
-
-    cd $SCRIPT_PATH/eco
-    local ECO_NUM_ACCOUNTS=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
-        --nousb --verbosity 0 account list | wc -l)
-    if [ $ECO_NUM_ACCOUNTS -ge 1 ]; then
-        echo_error "eco keystore file exist"
-        return
-    fi
-
-    if [ -f "$ECO_KEYSTORE_PASS_FILE" ]; then
-        echo_error "$ECO_KEYSTORE_PASS_FILE exist"
-        return
-    fi
-
-    echo "Creating eco keystore..."
-    gen_pass
-    if [ "$KEYSTORE_PASS" == "" ]; then
-        echo_error "empty password"
-        exit
-    fi
-
-    echo "Saving eco keystore password..."
-    mkdir -p $(dirname $ECO_KEYSTORE_PASS_FILE)
-    chmod 700 $(dirname $ECO_KEYSTORE_PASS_FILE)
-    echo $KEYSTORE_PASS > $ECO_KEYSTORE_PASS_FILE
-    chmod 600 $ECO_KEYSTORE_PASS_FILE
-
-    cd ${SCRIPT_PATH}/eco
-    ./eco --datadir "$SCRIPT_PATH/eco/data/" --verbosity 0 account new \
-        --password "$ECO_KEYSTORE_PASS_FILE" >/dev/null
-    if [ "$?" != "0" ]; then
-        echo_error "failed to create eco keystore"
-        return
-    fi
-
-    echo "Checking eco keystore..."
-    local ECO_KEYSTORE=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
-        --nousb --verbosity 0 account list | sed 's/.*keystore:\/\///')
-    chmod 600 $ECO_KEYSTORE
-
-    local ECO_MINER_ADDRESS_FILE=$SCRIPT_PATH/eco/data/miner_address.txt
-    echo "You can input an alternative eco reward address. (ENTER to skip)"
-    local ECO_MINER_ADDRESS=
-    read -p '? Miner Address: ' ECO_MINER_ADDRESS
-    if [ "$ECO_MINER_ADDRESS" != "" ]; then
-        mkdir -p $SCRIPT_PATH/eco/data
-        echo $ECO_MINER_ADDRESS | tee $ECO_MINER_ADDRESS_FILE
-        chmod 600 $ECO_MINER_ADDRESS_FILE
-    fi
-
-    echo_info "eco keystore file: $ECO_KEYSTORE"
-    echo_info "eco keystore password file: $ECO_KEYSTORE_PASS_FILE"
-    if [ -f $ECO_MINER_ADDRESS_FILE ]; then
-        echo_info "eco miner address file: $ECO_MINER_ADDRESS_FILE"
-    fi
-
-    touch ${SCRIPT_PATH}/eco/.init
-    echo_ok "eco initialized"
     echo
 }
 
@@ -3607,41 +3251,6 @@ esc-oracle_start()
     esc-oracle_status
 }
 
-eco-oracle_start()
-{
-    if [ ! -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
-        echo_error "$SCRIPT_PATH/eco-oracle/crosschain_eco.js is not exist"
-        return
-    fi
-
-    local PID=$(pgrep -fx 'node crosschain_eco.js')
-    if [ "$PID" != "" ]; then
-        eco-oracle_status
-        return
-    fi
-
-    echo "Starting eco-oracle..."
-    cd $SCRIPT_PATH/eco-oracle
-    mkdir -p $SCRIPT_PATH/eco-oracle/logs
-
-    if [ "$CHAIN_TYPE" == "mainnet" ]; then
-        export env=mainnet
-    elif [ "$CHAIN_TYPE" == "testnet" ]; then
-        export env=testnet
-    else
-        echo_error "do not support $CHAIN_TYPE"
-        return
-    fi
-
-    echo "env: $env"
-    nodejs_setenv
-    nohup $SHELL -c "node crosschain_eco.js \
-        2>$SCRIPT_PATH/eco-oracle/logs/eco-oracle_err.log \
-        | rotatelogs $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
-
-    sleep 1
-    eco-oracle_status
-}
 
 pgp-oracle_start()
 {
@@ -3730,20 +3339,6 @@ esc-oracle_stop()
     esc-oracle_status
 }
 
-eco-oracle_stop()
-{
-    local PID=$(pgrep -fx 'node crosschain_eco.js')
-    if [ "$PID" != "" ]; then
-        echo "Stopping eco-oracle..."
-        kill $PID
-        while ps -p $PID 1>/dev/null; do
-            echo -n .
-            sleep 1
-        done
-        echo
-    fi
-    eco-oracle_status
-}
 
 pgp-oracle_stop()
 {
@@ -3784,14 +3379,6 @@ esc-oracle_installed()
     fi
 }
 
-eco-oracle_installed()
-{
-    if [ -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
-        true
-    else
-        false
-    fi
-}
 
 pgp-oracle_installed()
 {
@@ -3820,14 +3407,6 @@ esc-oracle_ver()
     fi
 }
 
-eco-oracle_ver()
-{
-    if [ -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
-        echo "eco-oracle $(cat $SCRIPT_PATH/eco-oracle/*.js | shasum | cut -c 1-7)"
-    else
-        echo "eco-oracle N/A"
-    fi
-}
 
 pgp-oracle_ver()
 {
@@ -3878,36 +3457,6 @@ esc-oracle_status()
     echo
 }
 
-eco-oracle_status()
-{
-    local ECO_ORACLE_VER=$(eco-oracle_ver)
-
-    local ECO_ORACLE_DISK_USAGE=$(disk_usage $SCRIPT_PATH/eco-oracle)
-
-    local PID=$(pgrep -fx 'node crosschain_eco.js')
-    if [ "$PID" == "" ]; then
-        status_head $ECO_ORACLE_VER Stopped
-        status_info "Disk" "$ECO_ORACLE_DISK_USAGE"
-        echo
-        return
-    fi
-
-    local ECO_ORACLE_RAM=$(mem_usage $PID)
-    local ECO_ORACLE_UPTIME=$(run_time $PID)
-    local ECO_ORACLE_TCP_LISTEN=$(list_tcp $PID)
-    local ECO_ORACLE_NUM_TCPS=$(num_tcps $PID)
-    local ECO_ORACLE_NUM_FILES=$(num_files $PID)
-
-    status_head $ECO_ORACLE_VER Running
-    status_info "Disk"      "$ECO_ORACLE_DISK_USAGE"
-    status_info "PID"       "$PID"
-    status_info "RAM"       "$ECO_ORACLE_RAM"
-    status_info "Uptime"    "$ECO_ORACLE_UPTIME"
-    status_info "#Files"    "$ECO_ORACLE_NUM_FILES"
-    status_info "TCP Ports" "$ECO_ORACLE_TCP_LISTEN"
-    status_info "#TCP"      "$ECO_ORACLE_NUM_TCPS"
-    echo
-}
 
 pgp-oracle_status()
 {
@@ -3981,15 +3530,7 @@ esc-oracle_remove_log()
     remove_log $SCRIPT_PATH/esc-oracle/logs/esc-oracle_out-\*.log
 }
 
-eco-oracle_compress_log()
-{
-    compress_log $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-\*.log
-}
 
-eco-oracle_remove_log()
-{
-    remove_log $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-\*.log
-}
 
 pgp-oracle_compress_log()
 {
@@ -4076,40 +3617,6 @@ esc-oracle_update()
     fi
 }
 
-eco-oracle_update()
-{
-    unset OPTIND
-    while getopts "ny" OPTION; do
-        case $OPTION in
-            n)
-                local NO_START_AFTER_UPDATE=1
-                ;;
-            y)
-                local YES_TO_ALL=1
-                ;;
-        esac
-    done
-
-    chain_prepare_stage eco-oracle '*.js'
-    if [ "$?" != "0" ]; then
-        return
-    fi
-
-    local PATH_STAGE=$SCRIPT_PATH/.node-upload/eco-oracle
-    local DIR_DEPLOY=$SCRIPT_PATH/eco-oracle
-
-    local PID=$(pgrep -fx 'node crosschain_eco.js')
-    if [ $PID ]; then
-        eco-oracle_stop
-    fi
-
-    mkdir -p $DIR_DEPLOY
-    cp -v $PATH_STAGE/*.js $DIR_DEPLOY/
-
-    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
-        eco-oracle_start
-    fi
-}
 
 
 pgp-oracle_update()
@@ -4211,34 +3718,6 @@ esc-oracle_init()
     echo
 }
 
-eco-oracle_init()
-{
-    if [ ! -f ${SCRIPT_PATH}/eco/.init ]; then
-        echo_error "eco not initialized"
-        return
-    fi
-
-    if [ -f $SCRIPT_PATH/eco-oracle/.init ]; then
-        echo_error "eco-oracle has already been initialized"
-        return
-    fi
-
-    check_env_oracle
-
-    if [ ! -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
-        eco-oracle_update -y
-    fi
-
-    nodejs_setenv
-
-    mkdir -p $SCRIPT_PATH/eco-oracle
-    cd $SCRIPT_PATH/eco-oracle
-    npm install web3@1.7.3 express@4.18.1
-
-    touch ${SCRIPT_PATH}/eco-oracle/.init
-    echo_ok "eco-oracle initialized"
-    echo
-}
 
 
 pgp-oracle_init()
@@ -4964,7 +4443,7 @@ arbiter_start()
         else
             nohup ./arbiter 1>/dev/null 2>output &
         fi
-        echo "Waiting for ela, esc-oracle, eid-oracle, eco-oracle to start..."
+        echo "Waiting for ela, esc-oracle, eid-oracle to start..."
         sleep 5
     done
 
@@ -5092,22 +4571,6 @@ arbiter_status()
         ARBITER_EID_HEIGHT=N/A
     fi
 
-    # linda 添加ECO
-    if [ "$CHAIN_TYPE" == "mainnet" ]; then
-        local ECO_GENESIS=02820c5adc8ee4fb77aad842ac05d95ed8b1041d80c03ba79f8f11c4af60d87c
-    elif [ "$CHAIN_TYPE" == "testnet" ]; then
-        local ECO_GENESIS=3043bcc03c90a37a292a4357ee972bc392b143e75e1b79205e113688e3bd071b
-    else
-        echo_error "do not support $CHAIN_TYPE"
-        return
-    fi
-    local ARBITER_ECO_HEIGHT=$(arbiter_jsonrpc \
-        "{\"method\":\"getsidechainblockheight\",\"params\":{\"hash\":\"$ECO_GENESIS\"}}" \
-        | jq -r '.result')
-    if [[ ! "$ARBITER_ECO_HEIGHT" =~ ^[0-9]+$ ]]; then
-        ARBITER_ECO_HEIGHT=N/A
-    fi
-    # linda 添加
 
     # linda 添加PGP
 
@@ -5157,7 +4620,6 @@ arbiter_status()
     status_info "ESC Height" "$ARBITER_ESC_HEIGHT"
     status_info "EID Height" "$ARBITER_EID_HEIGHT"
     # linda 添加
-    status_info "ECO Height" "$ARBITER_ECO_HEIGHT"
     # linda 添加
     #status_info "PGP Height" "$ARBITER_PGP_HEIGHT"
     # linda 添加
@@ -5330,12 +4792,6 @@ arbiter_init()
         echo_error "eid-oracle not initialized"
         return
     fi
-    #linda添加ECO判断
-     if [ ! -f $SCRIPT_PATH/eco-oracle/.init ]; then
-        echo_error "eco-oracle not initialized"
-        return
-    fi
-    #linda添加
     #linda添加PGP判断
      if [ ! -f $SCRIPT_PATH/pgp-oracle/.init ]; then
         echo_error "pgp-oracle not initialized"
@@ -5413,21 +4869,6 @@ arbiter_init()
         "PowChain": false
       },
       {
-        "Name": "ECO",
-        "Rpc": {
-          "IpAddress": "127.0.0.1",
-          "HttpJsonPort": 20652
-        },
-        "SyncStartHeight": 0,
-        "ExchangeRate": 1,
-        "GenesisBlock": "3043bcc03c90a37a292a4357ee972bc392b143e75e1b79205e113688e3bd071b",
-        "SupportQuickRecharge": true,
-        "SupportInvalidDeposit": true,
-        "SupportInvalidWithdraw": true,
-        "SupportNFT": false,
-        "PowChain": false
-      },
-      {
         "Name": "PG",
         "Rpc": {
           "IpAddress": "127.0.0.1",
@@ -5493,21 +4934,6 @@ EOF
         "SupportQuickRecharge": true,
         "SupportInvalidDeposit": true,
         "SupportInvalidWithdraw": true,
-        "PowChain": false
-      },
-      {
-        "Name": "ECO",
-        "Rpc": {
-          "IpAddress": "127.0.0.1",
-          "HttpJsonPort": 20652
-        },
-        "SyncStartHeight": 0,
-        "ExchangeRate": 1,
-        "GenesisBlock": "02820c5adc8ee4fb77aad842ac05d95ed8b1041d80c03ba79f8f11c4af60d87c",
-        "SupportQuickRecharge": true,
-        "SupportInvalidDeposit": true,
-        "SupportInvalidWithdraw": true,
-        "SupportNFT": false,
         "PowChain": false
       },
       {
@@ -5648,8 +5074,6 @@ else
        [ "$1" != "esc-oracle" ] && \
        [ "$1" != "eid"        ] && \
        [ "$1" != "eid-oracle" ] && \
-       [ "$1" != "eco"        ] && \
-       [ "$1" != "eco-oracle" ] && \
        [ "$1" != "pgp"        ] && \
        [ "$1" != "pgp-oracle" ] && \
        [ "$1" != "pg"         ] && \

--- a/docs/overview/requirements.md
+++ b/docs/overview/requirements.md
@@ -61,11 +61,6 @@ If you do not need all the chains, please find a required subset by the chain na
 | EID                   | TCP 20646               | EID rpc           |
 | EID                   | TCP+UDP 20648           | EID P2P           |
 | EID                   | TCP 20649               | EID BPoS          |
-| ECO-bootnode          | UDP 20650               | ECO bootnode      |
-| ECO-oracle            | TCP 20652               | ECO oracle        |
-| ECO                   | TCP 20656               | ECO rpc           |
-| ECO                   | TCP+UDP 20658           | ECO P2P           |
-| ECO                   | TCP 20659               | ECO BPoS          |
 | Arbiter               | TCP 20536               | Arbiter rpc       |
 | Arbiter               | TCP 20538               | Arbiter P2P       |
 | Carrier               | UDP 3478                | Carrier P2P       |


### PR DESCRIPTION
## Summary

Removes the ECO sidechain from `build/skeleton/node.sh` and from the
operator network-ports documentation. After this PR merges, `node.sh`
no longer knows ECO exists — `./node.sh eco <anything>` is rejected by
the chain-name whitelist, `./node.sh all <verb>` skips ECO, and a fresh
`./node.sh arbiter init` generates a `config.json` whose `SideNodeList`
contains only ESC, EID, and PG.

## What's deleted

| Area | Count | Effect |
|---|---|---|
| `eco_*` function definitions | 10 | All ECO chain operations gone |
| `eco-oracle_*` function definitions | 9 | All ECO oracle operations gone |
| `chain_prepare_stage` whitelists | 4 sites | ECO/eco-oracle no longer accepted by staging |
| Main dispatcher whitelist | 1 site | ECO/eco-oracle no longer accepted by user invocation |
| `all_*` dispatcher loops | 7 functions | ECO removed from start/stop/status/update/init/log helpers |
| Arbiter status height query | 1 site | No more ECO Height query (incl. hardcoded mainnet genesis hash) |
| Arbiter status display row | 1 site | "ECO Height" row removed from status table |
| Arbiter init dependency check | 1 site | Arbiter init no longer requires eco-oracle/.init |
| Arbiter testnet config heredoc | 1 site | ECO entry removed from generated testnet config |
| Arbiter mainnet config heredoc | 1 site | ECO entry removed from generated mainnet config |
| Arbiter wait-message string | 1 patch | "eco-oracle" removed from startup wait message |
| `docs/overview/requirements.md` | 5 rows | ECO bootnode/oracle/RPC/P2P/BPoS ports |

**Net:** `node.sh` 5703 → 5127 lines (576 deleted + 1 string patched).
`requirements.md` -5 lines.

## Scope verification

Audited five sibling repositories in parallel before authoring this PR
(see commit message for the full list). None contain hardcoded ECO
references — the arbiter daemon in particular is fully `SideNodeList`-
driven via its `config.json`, so no companion PRs are required. Only
this repo needs changes.

The ECO mainnet genesis hash
`02820c5adc8ee4fb77aad842ac05d95ed8b1041d80c03ba79f8f11c4af60d87c`
only appears in `node.sh` (now removed) and in
`Elastos.ELA.SideChain.ECO/params/config.go` (preserved with that
soon-to-be-archived repo for historical reference).

## Test plan

Reviewer checks on a fresh checkout of this branch:

- [ ] `bash -n build/skeleton/node.sh` exits clean
- [ ] `grep -ic '\beco\b' build/skeleton/node.sh` returns `0`
- [ ] `grep -ic '\beco\b' docs/overview/requirements.md` returns `0`
- [ ] `grep -Ec 'eco_[a-z]+|eco-oracle_[a-z]+' build/skeleton/node.sh` returns `0`
- [ ] `grep -cE '20652|20656|20659' build/skeleton/node.sh` returns `0`
      (ECO oracle, RPC, and PBFT P2P ports are gone)
- [ ] Each of `ela_start`, `esc_start`, `eid_start`, `pg_start`, `arbiter_start`
      is still defined (`grep -cE '^(ela|esc|eid|pg|arbiter)_start' = 5`)
- [ ] Arbiter wait message reads `"Waiting for ela, esc-oracle, eid-oracle to start..."`
      (no `eco-oracle`)

Optional sanity:

- [ ] Generate a fresh arbiter config in a sandbox (`./node.sh arbiter init`)
      and confirm `jq '.Configuration.SideNodeList[].Name' arbiter/config.json`
      returns only `ESC`, `EID`, `PG`.

## Important — for live operators

This PR changes the source of truth, but it does **not** patch already-
deployed nodes. Operators with running ECO services should follow the
migration runbook (linked in the task description) before pulling this
version of `node.sh`:

1. Stop ECO services using the OLD `node.sh` (`eco-oracle stop` then `eco stop`)
2. `jq`-patch the live `arbiter/config.json` to drop the ECO `SideNodeList` entry
3. Restart the arbiter so it forgets ECO
4. Pull the new `node.sh`
5. Optionally archive `eco/` and `eco-oracle/` directories on disk

Without step 2, the arbiter will log `"failed to connect to side chain:
127.0.0.1:20652"` every few seconds until manually patched.

## Out of scope

- Archiving/deprecating the `Elastos.ELA.SideChain.ECO` repository
  (separate PR + GitHub repo archive)
- Any download-server-side archiving of ECO release tarballs at
  `download.elastos.io/elastos-eco/`
- Operator notifications and migration scheduling
