### PR TITLE
Fix arbiter_init blocked by orphaned pgp-oracle precondition

### DIFF
--- a/build/skeleton/node.sh
+++ b/build/skeleton/node.sh
@@ -4792,12 +4792,6 @@ arbiter_init()
         echo_error "eid-oracle not initialized"
         return
     fi
-    #linda添加PGP判断
-     if [ ! -f $SCRIPT_PATH/pgp-oracle/.init ]; then
-        echo_error "pgp-oracle not initialized"
-        return
-    fi
-    #linda添加
     #linda添加PG判断
     if [ ! -f $SCRIPT_PATH/pg-oracle/.init ]; then
         echo_error "pg-oracle not initialized"


### PR DESCRIPTION
## Summary

`arbiter_init` refuses to run unless `$SCRIPT_PATH/pgp-oracle/.init` exists,
but `pgp_init` and `pgp-oracle_init` are commented out in `all_init` so that
file is never created. Result: `./node.sh init` always fails at
`ERROR: pgp-oracle not initialized` on a fresh box, with no arbiter installed.

This is a pre-existing bug, surfaced (not caused) by recent partial PGP
deprecation work.

## Reproduction

```
mkdir ~/node && cd ~/node
curl -O https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/node.sh
chmod +x node.sh
./node.sh init
# … all chains init …
# ERROR: pgp-oracle not initialized   ← here
# arbiter directory never created
```

## Fix

Delete the 6-line orphaned precondition block from `arbiter_init`. No other
changes — `pgp_init`/`pgp-oracle_init` functions remain callable manually,
all existing chain checks for ela/esc-oracle/eid-oracle/pg-oracle are
preserved.

```
-    #linda添加PGP判断
-     if [ ! -f $SCRIPT_PATH/pgp-oracle/.init ]; then
-        echo_error "pgp-oracle not initialized"
-        return
-    fi
-    #linda添加
```

## Why this is safe (audit summary)

| Risk | Status | Evidence |
|---|---|---|
| Arbiter daemon needs PGP | ❌ No | Arbiter Go source has zero hardcoded PGP awareness; iterates `SideNodeList` by ordinal index |
| Existing operator configs reference PGP | ❌ Handled | `arbiter_remove_sidechain_config` (line 4741) already exists to strip PGP from on-disk configs |
| Heredoc-generated configs include PGP | ❌ No | Both testnet and mainnet heredocs contain only ESC, EID, PG |
| Status display references PGP | ❌ Already gone | `arbiter_status` PGP queries are already commented out (lines 57-106) |
| Operators have PGP installations to preserve | ❌ Near-zero | `Elastos.ELA.SideChain.PGP` source repo is 404 (deleted); only v0.0.1 alpha binaries remain on download server |
| Reintroducing PGP later is harder | ❌ No | `pgp_init`/`pgp-oracle_init` and all dispatcher entries remain intact (just commented) |

## Test plan

- [ ] `bash -n build/skeleton/node.sh` passes
- [ ] `sed -n '/^arbiter_init/,/^}/p' build/skeleton/node.sh | grep -c 'pgp-oracle/.init'` returns `0`
- [ ] `sed -n '/^arbiter_init/,/^}/p' build/skeleton/node.sh | grep -c 'pg-oracle/.init'` returns `1`
- [ ] `grep -cE '^pgp_init|^pgp-oracle_init' build/skeleton/node.sh` returns `2` (functions preserved)
- [ ] End-to-end: `mkdir test-node && cd test-node && cp ../node.sh . && ./node.sh init` completes through `arbiter initialized` with no error

## Companion to ECO removal

This is a small follow-up to #16 (Remove ECO chain support). Both PRs address
the same class of bug — orphaned `#linda添加` precondition checks in
`arbiter_init` left behind during partial chain-deprecation cleanups. With
both merged, `./node.sh init` completes end-to-end on a clean box for the
first time in a while.
