### PR TITLE
Elastos Node for Ubuntu: hardened node.sh runner (v1.1)

### DIFF
--- a/build/skeleton/install.sh
+++ b/build/skeleton/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# elastos-node installer / updater - one command for everyone.
+#
+#   curl -fsSL https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/install.sh | bash
+#
+# - Fresh box      -> installs node.sh, then tells you to run `node.sh setup`.
+# - Existing node  -> backs up the old node.sh, swaps in the fork, runs `migrate`
+#                     (writes the profile + a rollback snapshot; restarts NOTHING).
+# It verifies the published SHA-256 before installing, and never touches keystores
+# or chain data.
+set -euo pipefail
+
+REPO="https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton"
+NODE_DIR="${ELASTOS_NODE_DIR:-$HOME/node}"
+
+say()  { printf '%s\n' "$*"; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+command -v curl    >/dev/null || die "curl is required"
+command -v shasum  >/dev/null || command -v sha256sum >/dev/null || die "shasum/sha256sum is required"
+sha256() { if command -v shasum >/dev/null; then shasum -a 256 "$1"; else sha256sum "$1"; fi; }
+
+mkdir -p "$NODE_DIR"
+cd "$NODE_DIR"
+
+say "Downloading elastos-node (hardened fork)..."
+curl -fsSL -o node.sh.new "$REPO/node.sh" || die "download failed"
+
+want=$(curl -fsSL "$REPO/node.sh.sha256" 2>/dev/null | awk '{print $1}')
+if [ -n "$want" ]; then
+    got=$(sha256 node.sh.new | awk '{print $1}')
+    [ "$want" = "$got" ] || { rm -f node.sh.new; die "checksum mismatch - refusing to install"; }
+    say "  checksum verified"
+fi
+bash -n node.sh.new || { rm -f node.sh.new; die "downloaded script failed syntax check"; }
+
+# An existing install is one that already has a chain directory.
+existing=
+for d in ela esc eid pg; do [ -d "$NODE_DIR/$d" ] && existing=1; done
+
+if [ -f node.sh ] && [ -n "$existing" ]; then
+    bk="node.sh.pre-fork.$(date +%s)"
+    cp -p node.sh "$bk"
+    say "  previous node.sh backed up -> $bk"
+fi
+
+mv node.sh.new node.sh
+chmod +x node.sh
+say "  installed: $NODE_DIR/node.sh"
+say
+
+if [ -n "$existing" ]; then
+    say "Existing install detected - migrating onto the fork (nothing is restarted):"
+    say
+    ./node.sh migrate
+else
+    say "Fresh install. Next step:"
+    say "  cd $NODE_DIR && ./node.sh setup"
+fi

--- a/build/skeleton/node.sh
+++ b/build/skeleton/node.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# elastos-node - hardened fork of elastos/Elastos.Node
+ELASTOS_NODE_VERSION="1.1.0"
+
+# Reset override flags so a value inherited from the environment cannot silently enable them.
+FORCE_ELA=
+
 #
 # utility
 #
@@ -39,24 +45,372 @@ echo_ok()
     fi
 }
 
+#
+# UI: color + status glyphs, honoring NO_COLOR, --no-color, and non-TTY output.
+#
+UI_DOT_OK=$'\xe2\x97\x8f'      # filled circle  (running / healthy)
+UI_DOT_OFF=$'\xe2\x97\x8b'     # empty circle   (stopped)
+UI_DOT_WARN=$'\xe2\x97\x90'    # half circle    (attention)
+
+ui_use_color()
+{
+    [ -n "$NO_COLOR" ]    && return 1
+    [ -n "$UI_NO_COLOR" ] && return 1
+    [ -t 1 ]              || return 1
+    return 0
+}
+ui_c()  { if ui_use_color; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi; }
+ui_green()  { ui_c '1;32' "$1"; }
+ui_yellow() { ui_c '1;33' "$1"; }
+ui_red()    { ui_c '1;31' "$1"; }
+ui_dim()    { ui_c '2'    "$1"; }
+ui_bold()   { ui_c '1'    "$1"; }
+
+# chain_running <chain>: true if the chain's process is alive (no RPC, cannot hang).
+chain_running()
+{
+    case "$1" in
+        ela)        pgrep -x ela     >/dev/null 2>&1 ;;
+        arbiter)    pgrep -x arbiter >/dev/null 2>&1 ;;
+        esc|eco|pgp|pg|eid)
+                    pgrep -f "^\./$1 .*--rpc " >/dev/null 2>&1 ;;
+        esc-oracle) pgrep -fx 'node crosschain_oracle.js' >/dev/null 2>&1 ;;
+        eid-oracle) pgrep -fx 'node crosschain_eid.js'    >/dev/null 2>&1 ;;
+        eco-oracle) pgrep -fx 'node crosschain_eco.js'    >/dev/null 2>&1 ;;
+        pgp-oracle) pgrep -fx 'node crosschain_pgp.js'    >/dev/null 2>&1 ;;
+        pg-oracle)  pgrep -fx 'node crosschain_pg.js'     >/dev/null 2>&1 ;;
+        *)          return 1 ;;
+    esac
+}
+
+# EVM_CHAINS: the geth-based side chains (single source of truth).
+EVM_CHAINS="esc eco pgp pg eid"
+
+# is_evm_chain <chain>: true if <chain> is one of the EVM side chains.
+is_evm_chain() { case " $EVM_CHAINS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+# evm_rpc_bind: the address EVM chains bind RPC/WS to. Defaults to 127.0.0.1 (localhost
+# only). Override with the EVM_RPC_BIND env var (this session) or a persistent
+# ~/.config/elastos/evm_rpc_bind file. An invalid value falls back to 127.0.0.1
+# (fail-closed - a typo must never bind somewhere unintended).
+evm_rpc_bind()
+{
+    local b=$EVM_RPC_BIND
+    [ -z "$b" ] && [ -r ~/.config/elastos/evm_rpc_bind ] && b=$(tr -d '[:space:]' < ~/.config/elastos/evm_rpc_bind 2>/dev/null)
+    [ -z "$b" ] && b=127.0.0.1
+    echo "$b" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$' || b=127.0.0.1
+    echo "$b"
+}
+
+# did_you_mean <input> <valid words...>: print a suggestion for a near miss.
+did_you_mean()
+{
+    local input=$1; shift
+    local best= cand
+    for cand in $*; do case "$cand" in "$input"*) best=$cand; break ;; esac; done
+    [ -z "$best" ] && for cand in $*; do case "$cand" in *"$input"*) best=$cand; break ;; esac; done
+    [ -n "$best" ] && echo "  Did you mean '$best'?"
+}
+
+# verify_started <chain>: confirm the daemon is alive shortly after a start; if not,
+# surface the failure + the tail of its most recent log, so a dead-on-launch daemon is
+# reported immediately instead of inferred from a later "stopped" status.
+verify_started()
+{
+    local chain=$1 log bind
+    if chain_running "$chain"; then
+        if is_evm_chain "$chain"; then
+            bind=$(evm_rpc_bind)
+            if [ "$bind" == "127.0.0.1" ]; then
+                ui_dim "  $chain RPC/WS bound to 127.0.0.1 (localhost only; upstream was public 0.0.0.0). Remote access: SSH tunnel / reverse proxy."
+            else
+                echo_warn "$chain RPC/WS bound to $bind (PUBLIC - reachable off-box). Firewall it; persist via ~/.config/elastos/evm_rpc_bind, or set 127.0.0.1 to revert."
+            fi
+        fi
+        return 0
+    fi
+    echo_error "$chain failed to start (not running after launch)"
+    log=$(ls -t "$SCRIPT_PATH/$chain/logs/"*.log "$SCRIPT_PATH/$chain/elastos/logs/node/"*.log 2>/dev/null | head -1)
+    if [ -n "$log" ]; then
+        echo "  last lines of $(basename "$log"):"
+        tail -n 6 "$log" 2>/dev/null | sed 's/^/    /'
+    fi
+    return 1
+}
+
+# --- health data substrate (timeout-bounded; never hangs; error != 0) ---
+
+evm_port() { case "$1" in esc) echo 20636;; eco) echo 20656;; pgp) echo 20666;; pg) echo 20676;; eid) echo 20646;; *) return 1;; esac; }
+
+# evm_rpc <chain> <method> [params-json] : raw JSON response (curl capped at 3s)
+evm_rpc()
+{
+    local port; port=$(evm_port "$1") || return 1
+    curl -s --max-time 3 -X POST -H 'Content-Type: application/json' \
+        --data "{\"jsonrpc\":\"2.0\",\"method\":\"$2\",\"params\":${3:-[]},\"id\":1}" \
+        "http://127.0.0.1:$port" 2>/dev/null
+}
+
+# hex_to_dec <0x..> : decimal, or empty. Avoids the $(( )) octal/zero trap.
+hex_to_dec() { case "$1" in 0x*|0X*) echo $((16#${1#0[xX]})) ;; *) return 1 ;; esac; }
+
+evm_height() { local r; r=$(evm_rpc "$1" eth_blockNumber | jq -r '.result // empty' 2>/dev/null); hex_to_dec "$r"; }
+evm_peers()  { local r; r=$(evm_rpc "$1" net_peerCount  | jq -r '.result // empty' 2>/dev/null); hex_to_dec "$r"; }
+evm_syncing()
+{
+    local r; r=$(evm_rpc "$1" eth_syncing | jq -r '.result' 2>/dev/null)
+    [ -z "$r" ] && return 1
+    if [ "$r" == "false" ]; then echo synced; else echo syncing; fi
+}
+
+ela_height() { local h; h=$(ela_client info getcurrentheight 2>/dev/null);   [[ "$h" =~ ^[0-9]+$ ]] && echo "$h" || return 1; }
+ela_peers()  { local p; p=$(ela_client info getconnectioncount 2>/dev/null); [[ "$p" =~ ^[0-9]+$ ]] && echo "$p" || return 1; }
+
+# unified per-chain probes (ela vs EVM); services (oracle/arbiter) have no height/peers
+chain_height() { case "$1" in ela) ela_height ;; esc|eco|pgp|pg|eid) evm_height "$1" ;; *) return 1 ;; esac; }
+chain_peers()  { case "$1" in ela) ela_peers  ;; esc|eco|pgp|pg|eid) evm_peers  "$1" ;; *) return 1 ;; esac; }
+chain_synced() { case "$1" in ela) ela_synced 2>/dev/null && echo synced || echo syncing ;; esc|eco|pgp|pg|eid) evm_syncing "$1" ;; *) return 1 ;; esac; }
+
+# evm_reward_status <chain> : cold | hot | unset  (hot = reward addr == local keystore acct)
+evm_reward_status()
+{
+    local addr hot kf
+    [ -f "$SCRIPT_PATH/$1/data/miner_address.txt" ] && addr=$(tr -d '[:space:]' < "$SCRIPT_PATH/$1/data/miner_address.txt" 2>/dev/null)
+    echo "$addr" | grep -qiE '^0x[0-9a-f]{40}$' || { echo unset; return; }
+    kf=$(ls "$SCRIPT_PATH/$1/data/keystore/"UTC* 2>/dev/null | head -1)
+    [ -n "$kf" ] && hot=$(jq -r .address "$kf" 2>/dev/null)
+    if [ -n "$hot" ] && [ "$(echo "${addr#0x}" | tr A-Z a-z)" == "$(echo "$hot" | tr A-Z a-z)" ]; then
+        echo hot
+    else
+        echo cold
+    fi
+}
+
+# render_health <chain>: print a one-line verdict; exit 0 healthy, 1 if attention needed.
+# Designed for monitoring/cron: `node.sh esc health && ok || alert`.
+render_health()
+{
+    local chain=$1 p sy
+    "${chain}_installed" 2>/dev/null || { echo "$chain: not installed"; return 1; }
+    chain_running "$chain"           || { echo "$chain: stopped";       return 1; }
+    case "$chain" in
+        *-oracle|arbiter) echo "$chain: running"; return 0 ;;
+    esac
+    sy=$(chain_synced "$chain" 2>/dev/null)
+    p=$(chain_peers  "$chain" 2>/dev/null)
+    if [ -z "$sy" ] || [ -z "$p" ]; then echo "$chain: running (rpc unreachable)"; return 1; fi
+    [ "$sy" == "syncing" ]         && { echo "$chain: syncing";  return 1; }
+    [ -n "$p" ] && [ "$p" == "0" ] && { echo "$chain: no peers"; return 1; }
+    echo "$chain: healthy"; return 0
+}
+
+# render_health_all: health for every chain in the profile; exit non-zero if any unhealthy.
+render_health_all()
+{
+    local chain rc=0
+    for chain in $(profile_chains); do
+        render_health "$chain" || rc=1
+    done
+    return $rc
+}
+
+# render_summary: one row per chain in the active profile (the fleet glance).
+# chain_pid <chain>: the live PID (same detection as chain_running).
+chain_pid()
+{
+    case "$1" in
+        ela)        pgrep -x ela     2>/dev/null | head -1 ;;
+        arbiter)    pgrep -x arbiter 2>/dev/null | head -1 ;;
+        esc|eco|pgp|pg|eid) pgrep -f "^\./$1 .*--rpc " 2>/dev/null | head -1 ;;
+        esc-oracle) pgrep -fx 'node crosschain_oracle.js' 2>/dev/null | head -1 ;;
+        eid-oracle) pgrep -fx 'node crosschain_eid.js'    2>/dev/null | head -1 ;;
+        eco-oracle) pgrep -fx 'node crosschain_eco.js'    2>/dev/null | head -1 ;;
+        pgp-oracle) pgrep -fx 'node crosschain_pgp.js'    2>/dev/null | head -1 ;;
+        pg-oracle)  pgrep -fx 'node crosschain_pg.js'     2>/dev/null | head -1 ;;
+    esac
+}
+
+# render_status_one <chain>: the chain's own status block, with the noise fields
+# (Balance / PID / #Files / #TCP / port lists) removed. Labeled + aligned, like the
+# classic view the operator preferred - just without the clutter.
+render_status_one()
+{
+    # the familiar upstream labeled block, verbatim - one aligned field per line
+    "${1}_status"
+}
+
+# render_status_all: a card for every chain in the active profile.
+render_status_all()
+{
+    # one classic labeled block per chain, a blank line between - no extra chrome
+    local chain
+    echo
+    for chain in $(profile_chains); do "${chain}_status"; echo; done
+    echo "  $(ui_dim "one-line glance: $SCRIPT_NAME summary")"
+    echo
+}
+
+render_summary()
+{
+    local prof total=0 running=0 stopped=0 chain st glyph h p sy issues=
+    prof=$(get_profile)
+    echo
+    printf '  %s   profile: %s\n' "$(ui_bold 'Elastos node')" "$prof"
+    printf '  %-12s %-9s %-13s %-6s %s\n' 'CHAIN' 'STATE' 'HEIGHT' 'PEERS' 'HEALTH'
+    printf '  %s\n' '-------------------------------------------------------'
+    for chain in $(profile_chains); do
+        total=$((total + 1)); h='-'; p='-'
+        if ! "${chain}_installed" 2>/dev/null; then
+            st='-'; glyph=$(ui_dim "$UI_DOT_OFF")
+        elif chain_running "$chain"; then
+            st='running'; glyph=$(ui_green "$UI_DOT_OK"); running=$((running + 1))
+            h=$(chain_height "$chain" 2>/dev/null)
+            p=$(chain_peers  "$chain" 2>/dev/null)
+            case "$chain" in
+                *-oracle|arbiter) [ -z "$h" ] && h='-'; [ -z "$p" ] && p='-' ;;
+                *)                [ -z "$h" ] && h='?'; [ -z "$p" ] && p='?' ;;
+            esac
+            sy=$(chain_synced "$chain" 2>/dev/null)
+            if [ "$sy" == "syncing" ]; then glyph=$(ui_yellow "$UI_DOT_WARN"); issues="$issues $chain(syncing)"; fi
+            if [ -n "$p" ] && [ "$p" == "0" ]; then glyph=$(ui_red "$UI_DOT_WARN"); issues="$issues $chain(no-peers)"; fi
+        else
+            st='stopped'; glyph=$(ui_dim "$UI_DOT_OFF"); stopped=$((stopped + 1)); issues="$issues $chain(stopped)"
+        fi
+        printf '  %-12s %-9s %-13s %-6s %s\n' "$chain" "$st" "$h" "$p" "$glyph"
+    done
+    printf '  %s\n' '-------------------------------------------------------'
+    echo "  $(ui_green "$UI_DOT_OK") healthy   $(ui_yellow "$UI_DOT_WARN") syncing/attention   $(ui_dim "$UI_DOT_OFF") stopped"
+    if [ -z "$issues" ]; then
+        echo "  $(ui_green '✓') $running/$total running, all healthy"
+    else
+        echo "  $(ui_yellow '⚠') attention:$issues"
+    fi
+    echo
+}
+
+# chain_health_json <chain> / render_json_one / render_json_all : machine-readable
+chain_health_json()
+{
+    local chain=$1 inst=false run=false h='' p='' sy='' rw=''
+    "${chain}_installed" 2>/dev/null && inst=true
+    if [ "$inst" == true ] && chain_running "$chain"; then
+        run=true
+        h=$(chain_height "$chain" 2>/dev/null)
+        p=$(chain_peers  "$chain" 2>/dev/null)
+        sy=$(chain_synced "$chain" 2>/dev/null)
+        case "$chain" in esc|eco|pgp|pg|eid) rw=$(evm_reward_status "$chain" 2>/dev/null) ;; esac
+    fi
+    jq -n --arg chain "$chain" --argjson installed "$inst" --argjson running "$run" \
+          --arg height "$h" --arg peers "$p" --arg sync "$sy" --arg reward "$rw" \
+        '{chain:$chain, installed:$installed, running:$running,
+          height:(if $height=="" then null else ($height|tonumber) end),
+          peers:(if $peers=="" then null else ($peers|tonumber) end),
+          sync:(if $sync=="" then null else $sync end),
+          reward:(if $reward=="" then null else $reward end)}'
+}
+render_json_one() { chain_health_json "$1"; }
+render_json_all()
+{
+    local chain first=1
+    printf '['
+    for chain in $(profile_chains); do
+        [ $first -eq 1 ] || printf ','
+        first=0
+        chain_health_json "$chain"
+    done
+    printf ']\n'
+}
+
+# noninteractive: true when stdin is not a terminal (cron / CI / pipe). Used to take a
+# safe default instead of blocking on a read prompt.
+noninteractive() { [ ! -t 0 ]; }
+
+# profile_prompt_if_unset: ask main-chain-only vs full stack the first time.
+profile_prompt_if_unset()
+{
+    [ -n "$PROFILE_OVERRIDE" ] && return 0
+    [ -f "$PROFILE_FILE" ]     && return 0
+    echo "What will this node run?"
+    echo "  [1] Main chain only        (ELA)"
+    echo "  [2] Full stack             (ELA + side chains + oracles + arbiter)"
+    local sel
+    read -p '? Your option: [2] ' sel || { sel=2; echo "  (no input - defaulting to full stack)"; }
+    case "$sel" in
+        1) set_profile mainchain >/dev/null ;;
+        *) set_profile full      >/dev/null ;;
+    esac
+    echo
+}
+
 update_script()
 {
+    # The fork updates ITSELF (not upstream), so the hardening is never reverted.
     local SCRIPT_URL=https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/node.sh
+    local SHA_URL=https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/node.sh.sha256
 
     local SCRIPT=$SCRIPT_PATH/$(basename $BASH_SOURCE)
     local SCRIPT_TMP=$SCRIPT.tmp
 
     echo "Downloading $SCRIPT_URL..."
-    curl -# -o $SCRIPT_TMP $SCRIPT_URL
-    if [ "$?" != "0" ]; then
-        echo_error "curl failed"
-        return
+    if ! curl -fsSL -o "$SCRIPT_TMP" "$SCRIPT_URL"; then
+        echo_error "download failed"
+        rm -f "$SCRIPT_TMP"
+        return 1
     fi
 
-    mv $SCRIPT_TMP $SCRIPT
-    chmod a+x $SCRIPT
+    # Integrity: if a published checksum exists, the download MUST match it.
+    local WANT=$(curl -fsSL "$SHA_URL" 2>/dev/null | awk '{print $1}')
+    if [ -n "$WANT" ]; then
+        local GOT=$(shasum -a 256 "$SCRIPT_TMP" 2>/dev/null | awk '{print $1}')
+        if [ "$WANT" != "$GOT" ]; then
+            echo_error "checksum mismatch - refusing to update (want $WANT, got $GOT)"
+            rm -f "$SCRIPT_TMP"
+            return 1
+        fi
+        echo_ok "checksum verified"
+    else
+        echo_warn "no published checksum found - updating without integrity check"
+    fi
 
+    # Never install a script that does not parse.
+    if ! bash -n "$SCRIPT_TMP"; then
+        echo_error "downloaded script failed syntax check - refusing to update"
+        rm -f "$SCRIPT_TMP"
+        return 1
+    fi
+
+    mv "$SCRIPT_TMP" "$SCRIPT"
+    chmod a+x "$SCRIPT"
     echo_ok "$SCRIPT updated"
+    echo
+    # Re-exec the JUST-DOWNLOADED script's harden, not the old code still in memory, so
+    # any newly-added ports are closed in the same step (bash never reloads a running file).
+    "$SCRIPT" harden 2>/dev/null || harden_firewall
+}
+# has_cold_miner <chain>: true when the chain either does not mine or has a valid
+# cold reward address set. Silent; used by warn_hot_miner and status displays.
+has_cold_miner()
+{
+    local chain=$1
+    is_evm_chain "$chain" || return 0   # only EVM side chains mine
+    local pwfile=~/.config/elastos/${chain}.txt
+    local addrfile=$SCRIPT_PATH/${chain}/data/miner_address.txt
+    [ -f "$pwfile" ] || return 0   # not a mining node; nothing to check
+    local addr=
+    [ -f "$addrfile" ] && addr=$(tr -d '[:space:]' < "$addrfile" 2>/dev/null)
+    echo "$addr" | grep -qiE '^0x[0-9a-f]{40}$'
+}
+
+# warn_hot_miner <chain>: a mining chain with no cold reward address still starts,
+# but the operator is warned in red: rewards credit the node's LOCAL (hot) account.
+warn_hot_miner()
+{
+    local chain=$1
+    has_cold_miner "$chain" && return 0
+    echo "$(ui_red "WARNING: $chain is mining WITHOUT a cold reward address.")"
+    echo "$(ui_red "         Block rewards will credit this node's LOCAL (hot) account.")"
+    echo "  Set one, then restart:  $SCRIPT_NAME reward set 0xYOURCOLDADDRESS"
+    return 0
 }
 
 set_env()
@@ -155,7 +509,10 @@ check_env_oracle()
 
 init_config()
 {
-    local CONFIG_FILE=~/.config/elastos/${SCRIPT_NAME%.*}.json
+    # the network config is always node.json (Elastos convention), independent of the
+    # script's filename - so running this as e.g. node.sh.new (migration rehearsal) still
+    # finds the existing config instead of prompting and writing a stray file.
+    local CONFIG_FILE=~/.config/elastos/node.json
 
     if [ -f $CONFIG_FILE ]; then
         echo_error "$CONFIG_FILE exist"
@@ -170,7 +527,7 @@ init_config()
     local SELECT=
     while true; do
         echo
-        read -p '? Your option: [1] ' SELECT
+        read -p '? Your option: [1] ' SELECT || { SELECT=1; echo_info "no input - defaulting to MainNet"; }
 
         if [ "$SELECT" == "" ] || [ "$SELECT" == "1" ]; then
             local CHAIN_TYPE=mainnet
@@ -200,11 +557,15 @@ EOF
 
 load_config()
 {
-    local CONFIG_FILE=~/.config/elastos/${SCRIPT_NAME%.*}.json
+    # the network config is always node.json (Elastos convention), independent of the
+    # script's filename - so running this as e.g. node.sh.new (migration rehearsal) still
+    # finds the existing config instead of prompting and writing a stray file.
+    local CONFIG_FILE=~/.config/elastos/node.json
 
     if [ ! -f $CONFIG_FILE ]; then
+        # First run: choose the network and write the config, then CONTINUE with the
+        # requested command instead of exiting (no more running the command twice).
         init_config
-        exit
     fi
 
     export CHAIN_TYPE=$(cat $CONFIG_FILE | jq -r '.["chain-type"]')
@@ -561,7 +922,7 @@ get_elastos_ver_latest()
         return
     fi
 
-    curl -s "$1/?F=1" | grep '\[DIR\]' \
+    curl -s --connect-timeout 10 --max-time 30 "$1/?F=1" | grep '\[DIR\]' \
         | sed -e 's/.*href="//' -e 's/".*//' -e 's/.*-//' -e 's/\/$//' \
         | sort -Vr | head -n 1
 }
@@ -578,6 +939,8 @@ chain_prepare_stage()
        [ "$CHAIN_NAME" != "esc-oracle" ] && \
        [ "$CHAIN_NAME" != "eid" ] && \
        [ "$CHAIN_NAME" != "eid-oracle" ] && \
+       [ "$CHAIN_NAME" != "eco" ] && \
+       [ "$CHAIN_NAME" != "eco-oracle" ] && \
        [ "$CHAIN_NAME" != "pgp" ] && \
        [ "$CHAIN_NAME" != "pgp-oracle" ] && \
        [ "$CHAIN_NAME" != "pg" ] && \
@@ -596,6 +959,7 @@ chain_prepare_stage()
     if [ "$CHAIN_NAME" == "ela" ] || \
        [ "$CHAIN_NAME" == "esc" ] || \
        [ "$CHAIN_NAME" == "eid" ] || \
+       [ "$CHAIN_NAME" == "eco" ] || \
        [ "$CHAIN_NAME" == "pgp" ] || \
        [ "$CHAIN_NAME" == "pg" ] || \
        [ "$CHAIN_NAME" == "arbiter" ]; then
@@ -607,6 +971,7 @@ chain_prepare_stage()
             local RELEASE_PLATFORM=nosupport
         fi
     elif [ "$CHAIN_NAME" == "esc-oracle" ] || \
+         [ "$CHAIN_NAME" == "eco-oracle" ] || \
          [ "$CHAIN_NAME" == "pgp-oracle" ] || \
          [ "$CHAIN_NAME" == "pg-oracle" ] || \
          [ "$CHAIN_NAME" == "eid-oracle" ]; then
@@ -655,6 +1020,7 @@ chain_prepare_stage()
     fi
 
     if [ "$CHAIN_NAME" == "esc-oracle" ] || \
+       [ "$CHAIN_NAME" == "eco-oracle" ] || \
        [ "$CHAIN_NAME" == "pgp-oracle" ] || \
        [ "$CHAIN_NAME" == "pg-oracle" ] || \
        [ "$CHAIN_NAME" == "eid-oracle" ] ; then
@@ -699,76 +1065,577 @@ chain_prepare_stage()
 #
 # all
 #
+#
+# Deployment profile: mainchain-only vs the full cross-chain stack.
+#
+# Not every operator runs the whole stack. The profile is chosen once (persisted
+# to PROFILE_FILE) and governs the bulk commands (all_*) and the status summary.
+# An individual chain always works directly (e.g. `node.sh esc start`).
+# ECO and PGP are intentionally excluded (decommissioned).
+#
+PROFILE_FILE=~/.config/elastos/profile
+PROFILE_DEFAULT=full
+PROFILE_CHAINS_FULL="ela esc esc-oracle eid eid-oracle pg pg-oracle arbiter"
+PROFILE_CHAINS_MAINCHAIN="ela"
+
+# get_profile: echo the active profile, honoring --profile override, then the
+# persisted file, then the default. Always echoes a valid value.
+get_profile()
+{
+    local p="$PROFILE_OVERRIDE"
+    if [ -z "$p" ] && [ -f "$PROFILE_FILE" ]; then
+        p=$(cat "$PROFILE_FILE" 2>/dev/null | tr -d '[:space:]')
+    fi
+    case "$p" in
+        mainchain|full) echo "$p" ;;
+        *)              echo "$PROFILE_DEFAULT" ;;
+    esac
+}
+
+# profile_chains: ordered chain list for the active profile (start order).
+profile_chains()
+{
+    if [ "$(get_profile)" == "mainchain" ]; then
+        echo "$PROFILE_CHAINS_MAINCHAIN"
+    else
+        echo "$PROFILE_CHAINS_FULL"
+    fi
+}
+
+# set_profile <mainchain|full>: persist the operator's choice.
+set_profile()
+{
+    case "$1" in
+        mainchain|full)
+            mkdir -p "$(dirname "$PROFILE_FILE")"
+            echo "$1" > "$PROFILE_FILE"
+            echo "Deployment profile set to: $1"
+            echo "Active chains: $(profile_chains)"
+            ;;
+        *)
+            echo_error "unknown profile: '$1' (expected 'mainchain' or 'full')"
+            return 1
+            ;;
+    esac
+}
+
+# profile [set <p>]: show or change the deployment profile.
+profile()
+{
+    if [ "$1" == "set" ]; then
+        set_profile "$2"
+        return
+    fi
+    echo "Deployment profile: $(get_profile)"
+    echo "Active chains:      $(profile_chains)"
+    echo
+    echo "  mainchain   ELA mainchain only"
+    echo "  full        ELA + side chains (esc, eid, pg) + oracles + arbiter"
+    echo
+    echo "Change with: $SCRIPT_NAME profile set [mainchain|full]"
+}
+
+# firewall: open the peer + consensus ports for the active profile.
+# RPC/WS are deliberately NOT opened - they bind to 127.0.0.1 and must stay private.
+firewall()
+{
+    if ! command -v ufw >/dev/null 2>&1; then
+        echo_error "ufw not found (sudo apt-get install -y ufw)"; return 1
+    fi
+    local prof p; prof=$(get_profile)
+    echo "Opening peer/consensus ports for profile '$prof' (RPC stays on 127.0.0.1)..."
+    sudo ufw allow 22/tcp    >/dev/null   # SSH
+    sudo ufw allow 20338/tcp >/dev/null   # ELA P2P
+    sudo ufw allow 20339/tcp >/dev/null   # ELA DPoS
+    if [ "$prof" == "full" ]; then
+        for p in 20638 20648 20678; do    # EVM devp2p (tcp + udp discovery)
+            sudo ufw allow $p/tcp >/dev/null
+            sudo ufw allow $p/udp >/dev/null
+        done
+        for p in 20639 20649 20679; do    # EVM PBFT consensus
+            sudo ufw allow $p/tcp >/dev/null
+        done
+    fi
+    sudo ufw --force enable >/dev/null
+    echo_ok "firewall configured"
+    sudo ufw status verbose
+}
+
+# Local-only service ports that must never be reachable from the internet: EVM RPC/WS,
+# the ela RPC, the crosschain oracle HttpJsonPorts, and the arbiter RPC. Every one is
+# reached over loopback by the local geth / arbiter / CLI, which a host firewall never
+# blocks. P2P + consensus ports (the X8/X9 ports, and arbiter P2P 20538) stay OPEN.
+RPC_FIREWALL_PORTS="20336 20635 20636 20645 20646 20655 20656 20675 20676 20536 20632 20642 20652 20672"
+
+# harden_firewall: close public access to the RPC/WS ports. Safe, reversible, idempotent,
+# and it never restarts a daemon - so syncing and consensus are untouched. Returns 0.
+harden_firewall()
+{
+    local port closed=
+    if ! command -v ufw >/dev/null 2>&1; then
+        echo_warn "ufw not installed - make sure your cloud firewall blocks 20636/20646/20676 from the internet"
+        return 0
+    fi
+    if ! ufw status 2>/dev/null | grep -q "Status: active"; then
+        echo_warn "ufw inactive - make sure your cloud firewall blocks 20636/20646/20676 from the internet"
+        return 0
+    fi
+    for port in $RPC_FIREWALL_PORTS; do
+        if ufw status 2>/dev/null | grep -qE "^${port}/tcp[[:space:]].*ALLOW"; then
+            sudo ufw delete allow ${port}/tcp >/dev/null 2>&1 && closed="$closed $port"
+        fi
+    done
+    if [ -n "$closed" ]; then
+        echo_ok "firewall: closed public access to RPC ports:$closed"
+    else
+        echo_ok "firewall: no public RPC ports were open"
+    fi
+    return 0
+}
+
+# harden: the firewall close above, plus a report of which running EVM daemons still
+# bind 0.0.0.0 (and so need a restart to fully rebind to 127.0.0.1). Restarts nothing.
+harden()
+{
+    local chain pid cmd exposed=
+    ui_bold "Harden - close public RPC exposure"; echo
+    harden_firewall
+    echo
+    for chain in $EVM_CHAINS; do
+        pid=$(pgrep -f "^\./$chain .*--rpc " 2>/dev/null | head -1)
+        [ -z "$pid" ] && continue
+        cmd=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
+        if echo "$cmd" | grep -qE -- '0[.]0[.]0[.]0|--unlock '; then
+            echo "  $(ui_yellow '!') $chain still bound to 0.0.0.0 - restart to rebind:  $SCRIPT_NAME $chain restart"
+            exposed=1
+        fi
+    done
+    if [ -n "$exposed" ]; then
+        echo
+        echo "  The firewall change already blocks the internet. The restart is defense-in-depth"
+        echo "  (rebinds RPC to 127.0.0.1, drops --unlock/personal) - do it after each chain is synced."
+    else
+        echo_ok "all running EVM daemons are bound to 127.0.0.1"
+    fi
+}
+
+
+# setup: one-time host prep for a fresh Ubuntu box, then initialize the node.
+# Installs dependencies, adds swap, opens the firewall, enables autostart, runs init.
+# clean_orphaned_config: a deleted ~/node can leave ~/.config/elastos/<chain>.txt
+# (keystore passwords) with no matching keystore, which makes init bail half-way and
+# leaves a broken half-install. Detect that split-brain and offer to clear it.
+clean_orphaned_config()
+{
+    local chain orphan= ANSWER
+    for chain in ela esc eid pg; do
+        [ -f ~/.config/elastos/$chain.txt ] && [ ! -f "$SCRIPT_PATH/$chain/.init" ] && orphan="$orphan $chain"
+    done
+    [ -z "$orphan" ] && return 0
+    echo
+    echo_warn "leftover keystore passwords from a previous install (no matching keystore):$orphan"
+    echo "  these block init; the keystore they belonged to is already gone, so they are useless."
+    read -p "Remove them so init can proceed? (Yes/No) " ANSWER || { ANSWER=No; echo_warn "no input - leaving password files in place (remove manually if truly orphaned)"; }
+    case "$ANSWER" in
+        Yes|yes|y) for chain in $orphan; do rm -f ~/.config/elastos/$chain.txt && echo_ok "removed $chain.txt"; done ;;
+        *) echo_warn "left in place - init will fail for:$orphan  (remove them or run '$SCRIPT_PATH/$SCRIPT_NAME uninstall')" ;;
+    esac
+}
+
+setup()
+{
+    echo "=== Elastos node setup ==="
+    profile_prompt_if_unset
+    local prof; prof=$(get_profile)
+    echo "This will: install packages, add 16G swap, configure the firewall, enable"
+    echo "autostart, and initialize the '$prof' profile. It uses sudo."
+    local ANSWER
+    read -p "Proceed (Yes/No)? " ANSWER
+    if [ "$ANSWER" != "Yes" ] && [ "$ANSWER" != "yes" ] && [ "$ANSWER" != "y" ]; then
+        echo "Aborted."; return 1
+    fi
+
+    echo; echo "-- 1/5 dependencies --"
+    sudo apt-get update
+    sudo apt-get install -y jq lsof apache2-utils curl openssl ufw
+    [ "$prof" == "full" ] && sudo apt-get install -y nodejs npm make gcc
+
+    echo; echo "-- 2/5 swap (16G headroom for sync) --"
+    if [ "$(swapon --show 2>/dev/null | wc -l)" -eq 0 ] && [ ! -f /swapfile ]; then
+        sudo fallocate -l 16G /swapfile && sudo chmod 600 /swapfile
+        sudo mkswap /swapfile && sudo swapon /swapfile
+        grep -q '^/swapfile ' /etc/fstab 2>/dev/null || \
+            echo '/swapfile swap swap defaults 0 0' | sudo tee -a /etc/fstab >/dev/null
+        echo_ok "16G swap added"
+    else
+        echo "swap already present - skipping"
+    fi
+
+    echo; echo "-- 3/5 firewall --"
+    firewall
+
+    echo; echo "-- 4/5 autostart on reboot --"
+    ( crontab -l 2>/dev/null | grep -vE "node\.sh[[:space:]]+(start|compress_log)[[:space:]]*$"
+      echo "@reboot $SCRIPT_PATH/$SCRIPT_NAME start"
+      echo "*/10 * * * * $SCRIPT_PATH/$SCRIPT_NAME compress_log" ) | crontab -
+    echo_ok "autostart enabled (@reboot) + log compression every 10 minutes"
+    if printf '#!/bin/bash\nexec %s/%s "$@"\n' "$SCRIPT_PATH" "$SCRIPT_NAME" | sudo tee /usr/local/bin/node.sh >/dev/null 2>&1 && sudo chmod +x /usr/local/bin/node.sh 2>/dev/null; then
+        echo_ok "global command installed - run 'node.sh <command>' from anywhere"
+    else
+        echo_warn "could not install a global command; use $SCRIPT_PATH/$SCRIPT_NAME or ./node.sh"
+    fi
+
+    echo; echo "-- 5/5 initialize chains --"
+    all_init
+
+    echo; echo_ok "setup complete"
+    echo "Next steps:"
+    if [ "$prof" == "full" ]; then
+        echo "  1. set a COLD reward address for the side chains:"
+        echo "       node.sh reward set 0xYOURCOLDADDRESS"
+    fi
+    echo "  2. start:   node.sh up"
+    echo "  3. check:   node.sh status"
+    echo "  4. after full sync, get the 02/03... public key for Essentials:"
+    echo "       node.sh ela status --verbose"
+}
+
+# chain_restart <chain>: stop, wait for exit, start.
+chain_restart()
+{
+    local chain=$1 i
+    # never restart ELA unless explicitly forced - it would interrupt council consensus
+    if [ "$chain" == "ela" ] && [ "$FORCE_ELA" != "1" ]; then
+        echo_warn "ela restart refused: it would interrupt council consensus. Re-run with --force to include it."
+        return 0
+    fi
+    "${chain}_stop"
+    for i in 1 2 3 4 5; do chain_running "$chain" || break; sleep 1; done
+    "${chain}_start"
+}
+
+# all_restart: restart every chain in the active profile, one at a time.
+all_restart()
+{
+    local chain failed=
+    for chain in $(profile_chains); do
+        "${chain}_installed" 2>/dev/null || continue
+        chain_restart "$chain" || failed="$failed $chain"
+    done
+    if [ -n "$failed" ]; then
+        echo; echo_error "these chains did not restart:$failed"
+        return 1
+    fi
+    return 0
+}
+
+# chain_logs <chain> [-f]: tail the chain's most recent log (-f to follow).
+chain_logs()
+{
+    local chain=$1 follow= log
+    { [ "$2" == "-f" ] || [ "$2" == "--follow" ]; } && follow=1
+    log=$(ls -t "$SCRIPT_PATH/$chain/logs/"*.log "$SCRIPT_PATH/$chain/elastos/logs/node/"*.log 2>/dev/null | head -1)
+    if [ -z "$log" ]; then echo_error "no logs found for $chain yet"; return 1; fi
+    ui_dim "==> $log <=="; echo
+    if [ -n "$follow" ]; then tail -n 40 -f "$log"; else tail -n 60 "$log"; fi
+}
+
+# logs_cmd [<chain>] [-f]: global `logs`, defaults to the mainchain.
+logs_cmd()
+{
+    local chain=$1 flag=$2
+    if [ -z "$chain" ] || [ "$chain" == "-f" ] || [ "$chain" == "--follow" ]; then
+        flag=$chain; chain=ela
+    fi
+    chain_logs "$chain" "$flag"
+}
+
+# version_cmd: fork version + each installed chain binary version.
+version_cmd()
+{
+    echo "elastos-node $(ui_bold "v$ELASTOS_NODE_VERSION")  (hardened fork of elastos/Elastos.Node)"
+    ui_dim "node.sh sha:$SCRIPT_SHA1   profile:$(get_profile)"; echo
+    local chain
+    for chain in $(profile_chains); do
+        case "$chain" in *-oracle|arbiter) continue ;; esac
+        "${chain}_installed" 2>/dev/null && echo "  $("${chain}_ver" 2>/dev/null)"
+    done
+}
+
+# reward_cmd [set <0x..>]: show or set the cold miner reward address (EVM side chains).
+reward_cmd()
+{
+    local chain addr
+    if [ "$1" != "set" ]; then
+        echo "Cold reward address per side chain:"
+        for chain in esc eid pg; do
+            if [ -f "$SCRIPT_PATH/$chain/data/miner_address.txt" ]; then
+                echo "  $chain  $(cat "$SCRIPT_PATH/$chain/data/miner_address.txt")"
+            else
+                echo "  $chain  $(ui_yellow '(unset)')"
+            fi
+        done
+        echo; echo "Set for all side chains:  $SCRIPT_NAME reward set 0xYOURCOLDADDRESS"
+        return
+    fi
+    addr=$2
+    if ! echo "$addr" | grep -qiE '^0x[0-9a-f]{40}$'; then
+        echo_error "invalid address: '$addr' (expected 0x + 40 hex)"; return 1
+    fi
+    for chain in esc eid pg; do
+        mkdir -p "$SCRIPT_PATH/$chain/data"
+        echo "$addr" > "$SCRIPT_PATH/$chain/data/miner_address.txt"
+        chmod 600 "$SCRIPT_PATH/$chain/data/miner_address.txt"
+        echo_ok "$chain reward -> $addr"
+    done
+    echo "Restart the side chains to apply:  $SCRIPT_NAME esc restart   (etc.)"
+}
+
+# uninstall_cmd: stop everything and remove the install + config (destructive).
+uninstall_cmd()
+{
+    local ANSWER bk c
+    ui_red "This stops all chains and DELETES the install + config."; echo
+    echo "  removes: $SCRIPT_PATH/{ela,esc,eid,pg,*-oracle,arbiter,extern} and ~/.config/elastos"
+    echo "  the ELA keystore is backed up to ~/ first; chain DATA is gone."
+    if noninteractive; then echo_error "uninstall needs an interactive terminal - refusing to delete unattended"; return 1; fi
+    read -p "Type DELETE to confirm: " ANSWER
+    if [ "$ANSWER" != "DELETE" ]; then echo "Aborted."; return 1; fi
+    if [ -f "$SCRIPT_PATH/ela/keystore.dat" ]; then
+        bk=~/keystore.dat.bak.$(date +%s)
+        cp -p "$SCRIPT_PATH/ela/keystore.dat" "$bk" && echo_ok "keystore backed up -> $bk"
+    fi
+    all_stop 2>/dev/null
+    pkill -x ela 2>/dev/null; pkill -x arbiter 2>/dev/null
+    for c in $EVM_CHAINS; do pkill -f "^\./$c .*--rpc " 2>/dev/null; done
+    pkill -f 'node crosschain_' 2>/dev/null
+    crontab -l 2>/dev/null | grep -v 'node.sh' | crontab - 2>/dev/null
+    rm -rf "$SCRIPT_PATH"/ela "$SCRIPT_PATH"/esc "$SCRIPT_PATH"/eid "$SCRIPT_PATH"/pg \
+           "$SCRIPT_PATH"/eco "$SCRIPT_PATH"/pgp \
+           "$SCRIPT_PATH"/esc-oracle "$SCRIPT_PATH"/eid-oracle "$SCRIPT_PATH"/eco-oracle \
+           "$SCRIPT_PATH"/pgp-oracle "$SCRIPT_PATH"/pg-oracle "$SCRIPT_PATH"/arbiter \
+           "$SCRIPT_PATH"/extern "$SCRIPT_PATH"/.node-upload ~/.config/elastos
+    echo_ok "uninstalled (node.sh kept; remove with: rm $SCRIPT_PATH/$SCRIPT_NAME)"
+}
+
+# migrate_apply [--yes]: apply the hardened RPC binding with near-zero downtime.
+# Restarts ONLY stale side chains (esc/eid/pg), one at a time, verifying each comes
+# back on 127.0.0.1 before the next. The ELA mainchain is never restarted, so the
+# council producer keeps signing throughout. A single node cannot know fleet quorum -
+# coordinate across the council so only a few nodes restart a given chain at once.
+migrate_apply()
+{
+    local yes= chain pid cmd stale= ANSWER i ok
+    case "$1" in --yes|-y) yes=1 ;; esac
+
+    ui_bold "Apply hardening - staged restart of stale side chains"; echo
+    echo "  the ELA mainchain is NOT restarted; your consensus/producer stays online"
+    echo
+
+    for chain in $EVM_CHAINS; do
+        pid=$(pgrep -f "^\./$chain .*--rpc " 2>/dev/null | head -1)
+        [ -z "$pid" ] && continue
+        cmd=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
+        echo "$cmd" | grep -qE -- '0[.]0[.]0[.]0|--unlock ' || { echo_ok "$chain already hardened"; continue; }
+        [ "$chain" == "eco" ] && { echo "  $(ui_yellow '!') eco is decommissioned - left untouched; remove it with:  $SCRIPT_NAME eco purge"; continue; }
+        stale="$stale $chain"
+    done
+
+    if [ -z "$stale" ]; then
+        echo "Nothing to do - no stale side chain to restart."
+        return 0
+    fi
+    echo "Will restart, one at a time:$stale"
+    if [ -z "$yes" ]; then
+        if noninteractive; then echo_error "non-interactive: re-run '$SCRIPT_NAME migrate --apply --yes'"; return 1; fi
+        read -p "Proceed (Yes/No)? " ANSWER
+        case "$ANSWER" in Yes|yes|y) ;; *) echo "Aborted."; return 1 ;; esac
+    fi
+
+    for chain in $stale; do
+        echo; echo "-- restarting $chain --"
+        chain_restart "$chain"
+        ok=
+        for i in $(seq 1 30); do
+            if chain_running "$chain"; then
+                pid=$(pgrep -f "^\./$chain .*--rpc " 2>/dev/null | head -1)
+                cmd=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
+                echo "$cmd" | grep -qE -- '0[.]0[.]0[.]0|--unlock ' || { ok=1; break; }
+            fi
+            sleep 2
+        done
+        if [ -n "$ok" ]; then
+            echo_ok "$chain back up, hardened (127.0.0.1)"
+        else
+            echo_error "$chain did not come back hardened in time - check '$SCRIPT_NAME $chain status' before continuing"
+            return 1
+        fi
+    done
+
+    echo; echo_ok "all stale side chains hardened"
+    echo "Verify:  $SCRIPT_NAME summary"
+}
+
+# migrate [--dry-run]: move an existing install (old-fork or official Elastos)
+# onto this hardened fork. Preserves keystore + chaindata + config; only writes the
+# profile + a rollback snapshot; NEVER auto-restarts and NEVER deletes anything.
+migrate()
+{
+    local dryrun= src=fresh prof chain pid cmd a ts stale= need_reward=
+    case "$1" in
+        --apply)      migrate_apply "$2"; return $? ;;
+        --dry-run|-n) dryrun=1 ;;
+    esac
+
+    ui_bold "Migrate to the hardened elastos-node fork"; echo
+    [ -n "$dryrun" ] && { ui_dim "  dry-run: nothing will be changed"; echo; }
+    echo
+
+    # 1. detect the source install
+    if [ -f "$PROFILE_FILE" ]; then
+        src="old-fork"
+    elif [ -d "$SCRIPT_PATH/ela" ] || [ -d "$SCRIPT_PATH/esc" ] || [ -d "$SCRIPT_PATH/eid" ] || [ -d "$SCRIPT_PATH/pg" ]; then
+        src="official-upstream"
+    fi
+    echo "Source: $src"
+    if [ "$src" == "fresh" ]; then
+        echo "  no existing install found - run '$SCRIPT_NAME setup' instead."
+        return 0
+    fi
+
+    # 2. preflight - the node identity must be safe
+    echo; echo "Preflight:"
+    if [ -d "$SCRIPT_PATH/ela" ] && [ ! -f "$SCRIPT_PATH/ela/keystore.dat" ]; then
+        echo_error "ela/keystore.dat missing - node identity at risk. ABORTING (nothing changed)."
+        return 1
+    fi
+    [ -f "$SCRIPT_PATH/ela/keystore.dat" ] && echo_ok "ela keystore present (preserved, never touched)"
+    if [ -f ~/.config/elastos/node.json ]; then
+        if jq -e . ~/.config/elastos/node.json >/dev/null 2>&1; then
+            echo_ok "node.json valid"
+        else
+            echo_error "node.json is not valid JSON - fix it before migrating"; return 1
+        fi
+    fi
+
+    # 3. profile - official upstream has none, so infer it from what is installed
+    if [ -f "$PROFILE_FILE" ]; then
+        prof=$(get_profile); echo_ok "profile: $prof (kept)"
+    else
+        if [ -d "$SCRIPT_PATH/esc" ] || [ -d "$SCRIPT_PATH/eid" ] || [ -d "$SCRIPT_PATH/pg" ]; then prof=full; else prof=mainchain; fi
+        echo "  no profile (upstream) -> inferred: $prof"
+        if [ -z "$dryrun" ]; then
+            mkdir -p "$(dirname "$PROFILE_FILE")"; echo "$prof" > "$PROFILE_FILE"; echo_ok "profile written: $prof"
+        fi
+    fi
+
+    # 4. cold-miner bridge - a mining chain with no cold address will refuse to start
+    echo; echo "Mining reward addresses:"
+    for chain in esc eid pg; do
+        { [ -d "$SCRIPT_PATH/$chain" ] && [ -f ~/.config/elastos/$chain.txt ]; } || continue
+        a=
+        [ -f "$SCRIPT_PATH/$chain/data/miner_address.txt" ] && a=$(tr -d '[:space:]' < "$SCRIPT_PATH/$chain/data/miner_address.txt" 2>/dev/null)
+        if echo "$a" | grep -qiE '^0x[0-9a-f]{40}$'; then
+            echo_ok "$chain cold reward set"
+        else
+            echo "  $(ui_yellow '!') $chain is mining but has NO cold reward address"; need_reward=1
+        fi
+    done
+    [ -n "$need_reward" ] && echo "  set it before restarting:  $SCRIPT_NAME reward set 0xYOURCOLDADDR"
+
+    # 5. which running EVM chains are still on stale (unhardened) flags
+    echo; echo "Restart plan (to apply the hardened RPC binding):"
+    for chain in $EVM_CHAINS; do
+        pid=$(pgrep -f "^\./$chain .*--rpc " 2>/dev/null | head -1)
+        [ -z "$pid" ] && continue
+        cmd=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
+        if echo "$cmd" | grep -qE -- '0[.]0[.]0[.]0|--unlock '; then
+            echo "  $(ui_yellow '!') $chain is on OLD flags (public RPC) - restart to harden"; stale="$stale $chain"
+        else
+            echo_ok "$chain already hardened (127.0.0.1)"
+        fi
+    done
+    [ -z "$stale" ] && echo "  no running EVM chain needs a restart"
+
+    # leftover decommissioned ECO install (common on upstream nodes)
+    if [ -d "$SCRIPT_PATH/eco" ] || [ -d "$SCRIPT_PATH/eco-oracle" ] || [ -f ~/.config/elastos/eco.txt ]; then
+        echo
+        echo "  $(ui_yellow '!') decommissioned ECO chain detected on this node"
+        echo "    after migrating, stop + remove it with:  $SCRIPT_NAME eco purge"
+    fi
+
+    # 6. snapshot for rollback (live edit only)
+    if [ -z "$dryrun" ]; then
+        echo; echo "Snapshot (rollback point):"
+        ts=$(date +%s).$$
+        cp -p "$SCRIPT_PATH/$SCRIPT_NAME" "$SCRIPT_PATH/$SCRIPT_NAME.bak.$ts" 2>/dev/null && echo_ok "node.sh -> $SCRIPT_NAME.bak.$ts"
+        [ -d ~/.config/elastos ] && cp -rp ~/.config/elastos ~/.config/elastos.bak.$ts 2>/dev/null && echo_ok "config -> ~/.config/elastos.bak.$ts"
+    fi
+
+    # 7. hand control to the operator - never auto-restart
+    echo
+    if [ -n "$dryrun" ]; then
+        ui_bold "DRY-RUN complete"; echo " - re-run '$SCRIPT_NAME migrate' (no flag) to write the profile + snapshot AND close the public RPC firewall ports."
+    else
+        ui_bold "Migration prepared."; echo " The script is already swapped (zero downtime); daemons are still up."
+        echo
+        echo "Closing public RPC exposure (firewall only - safe, nothing is restarted):"
+        harden_firewall
+    fi
+    if [ -n "$stale" ]; then
+        echo "Apply the hardening - restart these ONE AT A TIME, staying above quorum:"
+        for chain in $stale; do echo "    $SCRIPT_NAME $chain restart"; done
+    fi
+    echo "Check anytime:    $SCRIPT_NAME summary"
+    echo "Update later:     $SCRIPT_NAME update_script   (pulls the latest fork, checksum-verified)"
+}
+
 all_start()
 {
-    ela_installed        && ela_start
-    esc_installed        && esc_start
-    esc-oracle_installed && esc-oracle_start
-    eid_installed        && eid_start
-    eid-oracle_installed && eid-oracle_start
-    #pgp_installed        && pgp_start
-    #pgp-oracle_installed && pgp-oracle_start
-    pg_installed         && pg_start
-    pg-oracle_installed  && pg-oracle_start
-    arbiter_installed    && arbiter_start
+    local chain
+    for chain in $(profile_chains); do
+        "${chain}_installed" || continue
+        "${chain}_start"
+    done
 }
 
 all_stop()
 {
-    arbiter_installed    && arbiter_stop
-    ela_installed        && ela_stop
-    eid-oracle_installed && eid-oracle_stop
-    eid_installed        && eid_stop
-    esc-oracle_installed && esc-oracle_stop
-    esc_installed        && esc_stop
-    #pgp_installed        && pgp_stop
-    #pgp-oracle_installed && pgp-oracle_stop
-    pg_installed         && pg_stop
-    pg-oracle_installed  && pg-oracle_stop
+    # stop in reverse start order for a clean shutdown
+    local chain reversed=
+    for chain in $(profile_chains); do
+        reversed="$chain $reversed"
+    done
+    for chain in $reversed; do
+        "${chain}_installed" && "${chain}_stop"
+    done
 }
 
 all_status()
 {
-    ela_installed        && ela_status
-    esc_installed        && esc_status
-    esc-oracle_installed && esc-oracle_status
-    eid_installed        && eid_status
-    eid-oracle_installed && eid-oracle_status
-    #pgp_installed        && pgp_status
-    #pgp-oracle_installed && pgp-oracle_status
-    pg_installed         && pg_status
-    pg-oracle_installed  && pg-oracle_status
-    arbiter_installed    && arbiter_status
+    local chain
+    for chain in $(profile_chains); do
+        "${chain}_installed" && "${chain}_status"
+    done
 }
 
 all_update()
 {
-    ela_installed        && ela_update
-    esc_installed        && esc_update
-    esc-oracle_installed && esc-oracle_update
-    eid_installed        && eid_update
-    eid-oracle_installed && eid-oracle_update
-    #pgp_installed        && pgp_update
-    #pgp-oracle_installed && pgp-oracle_update
-    pg_installed         && pg_update
-    pg-oracle_installed  && pg-oracle_update
-    arbiter_installed    && arbiter_update
+    local chain
+    for chain in $(profile_chains); do
+        "${chain}_installed" && "${chain}_update"
+    done
 }
 
 all_init()
 {
-    ela_init
-    esc_init
-    esc-oracle_init
-    eid_init
-    eid-oracle_init
-    #pgp_init
-    #pgp-oracle_init
-    pg_init
-    pg-oracle_init
-    arbiter_init
+    profile_prompt_if_unset
+    clean_orphaned_config
+    local chain
+    for chain in $(profile_chains); do
+        "${chain}_init"
+    done
 }
-
 all_compress_log()
 {
     ela_installed        && ela_compress_log
@@ -776,6 +1643,8 @@ all_compress_log()
     esc-oracle_installed && esc-oracle_compress_log
     eid_installed        && eid_compress_log
     eid-oracle_installed && eid-oracle_compress_log
+    eco_installed        && eco_compress_log
+    eco-oracle_installed && eco-oracle_compress_log
     #pgp_installed        && pgp_compress_log
     #pgp-oracle_installed && pgp-oracle_compress_log
     pg_installed         && pg_compress_log
@@ -790,6 +1659,8 @@ all_remove_log()
     esc-oracle_installed && esc-oracle_remove_log
     eid_installed        && eid_remove_log
     eid-oracle_installed && eid-oracle_remove_log
+    eco_installed        && eco_remove_log
+    eco-oracle_installed && eco-oracle_remove_log
     #pgp_installed        && pgp_remove_log
     #pgp-oracle_installed && pgp-oracle_remove_log
     pg_installed         && pg_remove_log
@@ -840,10 +1711,42 @@ ela_usage()
     echo
 }
 
+# ensure_sponsors: the ELA mainchain needs a `sponsors` file (height->sponsor lookup)
+# to validate blocks past the RecordSponsor fork (~1.8M). Upstream never fetches it, so
+# fresh nodes stall with "sponsors file not exist!". Download it if missing (mainnet only).
+ensure_sponsors()
+{
+    [ "$CHAIN_TYPE" == "mainnet" ] || return 0
+    local f=$SCRIPT_PATH/ela/sponsors
+    [ -s "$f" ] && return 0
+    local pfx=https://download.elastos.io/elastos-ela ver v
+    ver=$(get_elastos_ver_latest "$pfx" 2>/dev/null)
+    echo "Fetching the ELA sponsors file (~28MB, one-time; needed past block ~1.8M)..."
+    echo "  on a slow link this can take a few minutes - safe to wait; do not interrupt."
+    for v in "$ver" v0.9.9; do
+        [ -z "$v" ] && continue
+        if curl -fsSL --connect-timeout 15 --speed-limit 1024 --speed-time 30 --max-time 600 "$pfx/elastos-ela-$v/sponsors" -o "$f.tmp" 2>/dev/null \
+           && [ -s "$f.tmp" ] && ! head -c 200 "$f.tmp" | grep -qi '<html'; then
+            mv "$f.tmp" "$f"
+            echo_ok "sponsors file installed ($v, $(wc -l < "$f") entries)"
+            return 0
+        fi
+    done
+    rm -f "$f.tmp"
+    echo_warn "could not fetch the sponsors file - the mainchain may stall past block ~1.8M"
+    echo_warn "fetch it manually:  curl -fsSL $pfx/elastos-ela-v0.9.9/sponsors -o $f"
+    return 1
+}
+
 ela_start()
 {
     if [ ! -f $SCRIPT_PATH/ela/ela ]; then
         echo_error "$SCRIPT_PATH/ela/ela is not exist"
+        return
+    fi
+
+    if [ ! -f $SCRIPT_PATH/ela/config.json ]; then
+        echo_error "ela is not initialized (no config.json) - run:  $SCRIPT_PATH/$SCRIPT_NAME ela init"
         return
     fi
 
@@ -853,6 +1756,8 @@ ela_start()
         return
     fi
 
+    ensure_sponsors
+
     echo "Starting ela..."
     cd $SCRIPT_PATH/ela
     if [ -f ~/.config/elastos/ela.txt ]; then
@@ -861,6 +1766,7 @@ ela_start()
         nohup ./ela 1>/dev/null 2>output &
     fi
     sleep 1
+    verify_started ela
     ela_status
 }
 
@@ -1051,7 +1957,7 @@ ela_status()
 
     local ELA_NUM_PEERS=$(ela_client info getconnectioncount)
     if [[ ! "$ELA_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        ELA_NUM_PEERS=0
+        ELA_NUM_PEERS=N/A
     fi
     local ELA_HEIGHT=$(ela_client info getcurrentheight)
     if [[ ! "$ELA_HEIGHT" =~ ^[0-9]+$ ]]; then
@@ -1089,10 +1995,16 @@ ela_status()
         ELA_DPOS_VOTES=N/A
     fi
 
-    local ELA_DPOS_REWARDS=$(ela_jsonrpc dposv2rewardinfo |
-        jq -r ".result[]? | select(.address == \"$ELA_ADDRESS\") | .claimable")
-    if [ "$ELA_DPOS_REWARDS" == "" ]; then
-        ELA_DPOS_REWARDS=N/A
+    # dposv2rewardinfo (all-address form) ranges a live, unlocked consensus map in
+    # the ELA daemon and panics it during sync (concurrent map iteration + write).
+    # Only query it once the node is fully synced; otherwise report N/A.
+    local ELA_DPOS_REWARDS=N/A
+    if ela_synced 2>/dev/null; then
+        ELA_DPOS_REWARDS=$(ela_jsonrpc dposv2rewardinfo |
+            jq -r ".result[]? | select(.address == \"$ELA_ADDRESS\") | .claimable")
+        if [ "$ELA_DPOS_REWARDS" == "" ]; then
+            ELA_DPOS_REWARDS=N/A
+        fi
     fi
 
     local ELA_CRC_NAME=$(ela_jsonrpc listcurrentcrs state all |
@@ -2112,12 +3024,12 @@ esc_start()
     mkdir -p $SCRIPT_PATH/esc/logs/
 
     if [ -f ~/.config/elastos/esc.txt ]; then
+        warn_hot_miner esc
         if [ -f $SCRIPT_PATH/esc/data/miner_address.txt ]; then
             local ESC_OPTS="$ESC_OPTS --pbft.miner.address $SCRIPT_PATH/esc/data/miner_address.txt"
         fi
         nohup $SHELL -c "./esc \
             $ESC_OPTS \
-            --allow-insecure-unlock \
             --datadir $SCRIPT_PATH/esc/data \
             --mine \
             --miner.threads 1 \
@@ -2127,13 +3039,12 @@ esc_start()
             --pbft.net.address '$(extip)' \
             --pbft.net.port 20639 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'db,eth,net,pbft,personal,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool,pbft' \
             --rpcvhosts '*' \
             --syncmode full \
-            --unlock '0x$(cat $SCRIPT_PATH/esc/data/keystore/UTC* | jq -r .address)' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --frozen.account.list 0xD3651037F719CC3f38ef819f919972e04A0762d4 \
             --frozen.account.list 0xd5300C4091C4C45787C1BcB2b3d089F6a6094498 \
             --frozen.account.list 0xE4F50ec2E5E75d28647ce11Fd249f1Bf44be4269 \
@@ -2154,20 +3065,92 @@ esc_start()
             --datadir $SCRIPT_PATH/esc/data \
             --lightserv 10 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'admin,eth,net,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool' \
             --rpcvhosts '*' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --wsorigins '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/esc/logs/esc-%Y-%m-%d-%H_%M_%S.log 20M" &
     fi
 
     sleep 3
+    verify_started esc
     esc_status
 }
 
+eco_start()
+{
+    if [ ! -f $SCRIPT_PATH/eco/eco ]; then
+        echo_error "$SCRIPT_PATH/eco/eco is not exist"
+        return
+    fi
+
+    if [ "$CHAIN_TYPE" == "mainnet" ]; then
+        local ECO_OPTS=
+    elif [ "$CHAIN_TYPE" == "testnet" ]; then
+        local ECO_OPTS=--testnet
+    else
+        echo_error "do not support $CHAIN_TYPE"
+        return
+    fi
+
+    local PID=$(pgrep -f '^\./eco .*--rpc ')
+    if [ "$PID" != "" ]; then
+        eco_status
+        return
+    fi
+
+    echo "Starting eco..."
+    cd $SCRIPT_PATH/eco
+    mkdir -p $SCRIPT_PATH/eco/logs/
+
+    if [ -f ~/.config/elastos/eco.txt ]; then
+        warn_hot_miner eco
+        if [ -f $SCRIPT_PATH/eco/data/miner_address.txt ]; then
+            local ECO_OPTS="$ECO_OPTS --pbft.miner.address $SCRIPT_PATH/eco/data/miner_address.txt"
+        fi
+        nohup $SHELL -c "./eco \
+            $ECO_OPTS \
+            --datadir $SCRIPT_PATH/eco/data \
+            --mine \
+            --miner.threads 1 \
+            --password ~/.config/elastos/eco.txt \
+            --pbft.keystore ${SCRIPT_PATH}/ela/keystore.dat \
+            --pbft.keystore.password ~/.config/elastos/ela.txt \
+            --pbft.net.address '$(extip)' \
+            --pbft.net.port 20659 \
+            --rpc \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool,pbft' \
+            --rpcvhosts '*' \
+            --syncmode full \
+            --ws \
+            --wsaddr '$(evm_rpc_bind)' \
+            --wsorigins '*' \
+            2>&1 \
+            | rotatelogs $SCRIPT_PATH/eco/logs/eco-%Y-%m-%d-%H_%M_%S.log 20M" &
+    else
+        nohup $SHELL -c "./eco \
+            $ECO_OPTS \
+            --datadir $SCRIPT_PATH/eco/data \
+            --lightserv 10 \
+            --rpc \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool' \
+            --rpcvhosts '*' \
+            --ws \
+            --wsaddr '$(evm_rpc_bind)' \
+            --wsorigins '*' \
+            2>&1 \
+            | rotatelogs $SCRIPT_PATH/eco/logs/eco-%Y-%m-%d-%H_%M_%S.log 20M" &
+    fi
+
+    sleep 3
+    verify_started eco
+    eco_status
+}
 
 pgp_start()
 {
@@ -2196,12 +3179,12 @@ pgp_start()
     mkdir -p $SCRIPT_PATH/pgp/logs/
 
     if [ -f ~/.config/elastos/pgp.txt ]; then
+        warn_hot_miner pgp
         if [ -f $SCRIPT_PATH/pgp/data/miner_address.txt ]; then
             local PGP_OPTS="$PGP_OPTS --pbft.miner.address $SCRIPT_PATH/pgp/data/miner_address.txt"
         fi
         nohup $SHELL -c "./pgp \
             $PGP_OPTS \
-            --allow-insecure-unlock \
             --datadir $SCRIPT_PATH/pgp/data \
             --mine \
             --miner.threads 1 \
@@ -2211,13 +3194,12 @@ pgp_start()
             --pbft.net.address '$(extip)' \
             --pbft.net.port 20669 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'db,eth,net,pbft,personal,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool,pbft' \
             --rpcvhosts '*' \
             --syncmode full \
-            --unlock '0x$(cat $SCRIPT_PATH/pgp/data/keystore/UTC* | jq -r .address)' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --wsorigins '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/pgp/logs/pgp-%Y-%m-%d-%H_%M_%S.log 20M" &
@@ -2227,17 +3209,18 @@ pgp_start()
             --datadir $SCRIPT_PATH/pgp/data \
             --lightserv 10 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'admin,eth,net,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool' \
             --rpcvhosts '*' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --wsorigins '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/pgp/logs/pgp-%Y-%m-%d-%H_%M_%S.log 20M" &
     fi
 
     sleep 3
+    verify_started pgp
     pgp_status
 }
 
@@ -2269,12 +3252,12 @@ pg_start()
     mkdir -p $SCRIPT_PATH/pg/logs/
 
     if [ -f ~/.config/elastos/pg.txt ]; then
+        warn_hot_miner pg
         if [ -f $SCRIPT_PATH/pg/data/miner_address.txt ]; then
             local PG_OPTS="$PG_OPTS --pbft.miner.address $SCRIPT_PATH/pg/data/miner_address.txt"
         fi
         nohup $SHELL -c "./pg \
             $PG_OPTS \
-            --allow-insecure-unlock \
             --datadir $SCRIPT_PATH/pg/data \
             --mine \
             --miner.threads 1 \
@@ -2284,13 +3267,12 @@ pg_start()
             --pbft.net.address '$(extip)' \
             --pbft.net.port 20679 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'db,eth,net,pbft,personal,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool,pbft' \
             --rpcvhosts '*' \
             --syncmode full \
-            --unlock '0x$(cat $SCRIPT_PATH/pg/data/keystore/UTC* | jq -r .address)' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --wsorigins '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/pg/logs/pg-%Y-%m-%d-%H_%M_%S.log 20M" &
@@ -2300,17 +3282,18 @@ pg_start()
             --datadir $SCRIPT_PATH/pg/data \
             --lightserv 10 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'admin,eth,net,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool' \
             --rpcvhosts '*' \
             --ws \
-            --wsaddr '0.0.0.0' \
+            --wsaddr '$(evm_rpc_bind)' \
             --wsorigins '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/pg/logs/pg-%Y-%m-%d-%H_%M_%S.log 20M" &
     fi
 
     sleep 3
+    verify_started pg
     pg_status
 }
 
@@ -2328,6 +3311,21 @@ esc_stop()
     fi
     sync
     esc_status
+}
+eco_stop()
+{
+    local PID=$(pgrep -f '^\./eco .*--rpc ')
+    if [ "$PID" != "" ]; then
+        echo "Stopping eco..."
+        kill -s SIGINT $PID
+        while ps -p $PID 1>/dev/null; do
+            echo -n .
+            sleep 1
+        done
+        echo
+    fi
+    sync
+    eco_status
 }
 
 pgp_stop()
@@ -2371,6 +3369,14 @@ esc_installed()
     fi
 }
 
+eco_installed()
+{
+    if [ -f $SCRIPT_PATH/eco/eco ]; then
+        true
+    else
+        false
+    fi
+}
 
 pgp_installed()
 {
@@ -2399,6 +3405,14 @@ esc_ver()
     fi
 }
 
+eco_ver()
+{
+    if [ -f $SCRIPT_PATH/eco/eco ]; then
+        echo "eco $($SCRIPT_PATH/eco/eco version | grep 'Git Commit:' | sed 's/.* //' | cut -c1-7)"
+    else
+        echo "eco N/A"
+    fi
+}
 
 pgp_ver()
 {
@@ -2436,6 +3450,23 @@ esc_client()
     fi
 }
 
+eco_client()
+{
+    if [ ! -f $SCRIPT_PATH/eco/eco ]; then
+        echo_error "$SCRIPT_PATH/eco/eco is not exist"
+        return
+    fi
+
+    cd $SCRIPT_PATH/eco
+    if [ "$1" == "" ]; then
+        ./eco --datadir $SCRIPT_PATH/eco/data --help
+    elif [ "$1" == "attach" ] &&
+         [ ! -S $SCRIPT_PATH/eco/data/geth.ipc ]; then
+        return
+    else
+        ./eco --datadir $SCRIPT_PATH/eco/data --nousb $*
+    fi
+}
 
 pgp_client()
 {
@@ -2489,6 +3520,21 @@ esc_jsonrpc()
         http://127.0.0.1:20636 | jq .
 }
 
+eco_jsonrpc()
+{
+    if [ "$1" == "" ]; then
+        return
+    fi
+
+    if [[ $1 =~ ^[_3a-zA-Z]+$ ]] && [ "$2" == "" ]; then
+        local DATA="{\"method\":\"$1\",\"id\":0}"
+    else
+        local DATA=$1
+    fi
+
+    curl -s -H 'Content-Type:application/json' -X POST --data $DATA \
+        http://127.0.0.1:20656 | jq .
+}
 
 pgp_jsonrpc()
 {
@@ -2565,14 +3611,14 @@ esc_status()
     local ESC_NUM_PEERS=$(esc_jsonrpc \
         '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
         | jq -r '.result')
-    ESC_NUM_PEERS=$(($ESC_NUM_PEERS))
+    ESC_NUM_PEERS=$(hex_to_dec "$ESC_NUM_PEERS")
     if [[ ! "$ESC_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        ESC_NUM_PEERS=0
+        ESC_NUM_PEERS=N/A
     fi
     local ESC_HEIGHT=$(esc_jsonrpc \
         '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
         | jq -r '.result')
-    ESC_HEIGHT=$(($ESC_HEIGHT))
+    ESC_HEIGHT=$(hex_to_dec "$ESC_HEIGHT")
     if [[ ! "$ESC_HEIGHT" =~ ^[0-9]+$ ]]; then
         ESC_HEIGHT=N/A
     fi
@@ -2602,6 +3648,85 @@ esc_status()
     echo
 }
 
+eco_status()
+{
+    local ECO_VER=$(eco_ver)
+
+    local ECO_DISK_USAGE=$(disk_usage $SCRIPT_PATH/eco)
+
+    if [ -f ~/.config/elastos/eco.txt ]; then
+        cd $SCRIPT_PATH/eco
+        local ECO_KEYSTORE=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
+            --nousb --verbosity 0 account list | sed -n '1 s/.*keystore:\/\///p')
+        if [ $ECO_KEYSTORE ] && [ -f $ECO_KEYSTORE ]; then
+            local ECO_ADDRESS=0x$(cat $ECO_KEYSTORE | jq -r .address)
+        else
+            local ECO_ADDRESS=N/A
+        fi
+    else
+        local ECO_ADDRESS=N/A
+    fi
+
+    local ECO_MINER_ADDRESS=$(cat $SCRIPT_PATH/eco/data/miner_address.txt 2>/dev/null)
+    if [ "$ECO_MINER_ADDRESS" == "" ]; then
+        local ECO_MINER_ADDRESS=$ECO_ADDRESS
+    fi
+
+    local PID=$(pgrep -f '^\./eco .*--rpc ')
+    if [ "$PID" == "" ]; then
+        status_head $ECO_VER  Stopped
+        status_info "Disk"    "$ECO_DISK_USAGE"
+        status_info "Address" "$ECO_ADDRESS"
+        echo
+        return
+    fi
+
+    local ECO_RAM=$(mem_usage $PID)
+    local ECO_UPTIME=$(run_time $PID)
+    local ECO_NUM_TCPS=$(num_tcps $PID)
+    local ECO_TCP_LISTEN=$(list_tcp $PID)
+    local ECO_UDP_LISTEN=$(list_udp $PID)
+    local ECO_NUM_FILES=$(num_files $PID)
+
+    local ECO_NUM_PEERS=$(eco_jsonrpc \
+        '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
+        | jq -r '.result')
+    ECO_NUM_PEERS=$(hex_to_dec "$ECO_NUM_PEERS")
+    if [[ ! "$ECO_NUM_PEERS" =~ ^[0-9]+$ ]]; then
+        ECO_NUM_PEERS=N/A
+    fi
+    local ECO_HEIGHT=$(eco_jsonrpc \
+        '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+        | jq -r '.result')
+    ECO_HEIGHT=$(hex_to_dec "$ECO_HEIGHT")
+    if [[ ! "$ECO_HEIGHT" =~ ^[0-9]+$ ]]; then
+        ECO_HEIGHT=N/A
+    fi
+
+    local ECO_BALANCE=$(eco_client \
+        attach --exec "web3.fromWei(eth.getBalance('$ECO_ADDRESS'),'ether')")
+    if [ "$ECO_BALANCE" == "" ]; then
+        ECO_BALANCE=N/A
+    elif [[ $ECO_BALANCE =~ [^.0-9e-] ]]; then
+        ECO_BALANCE=N/A
+    fi
+
+    status_head $ECO_VER Running
+    status_info "Disk"      "$ECO_DISK_USAGE"
+    status_info "Address"   "$ECO_ADDRESS"
+    status_info "Balance"   "$ECO_BALANCE"
+    status_info "Miner"     "$ECO_MINER_ADDRESS"
+    status_info "PID"       "$PID"
+    status_info "RAM"       "$ECO_RAM"
+    status_info "Uptime"    "$ECO_UPTIME"
+    status_info "#Files"    "$ECO_NUM_FILES"
+    status_info "TCP Ports" "$ECO_TCP_LISTEN"
+    status_info "#TCP"      "$ECO_NUM_TCPS"
+    status_info "UDP Ports" "$ECO_UDP_LISTEN"
+    status_info "#Peers"    "$ECO_NUM_PEERS"
+    status_info "Height"    "$ECO_HEIGHT"
+    echo
+}
 
 
 pgp_status()
@@ -2647,14 +3772,14 @@ pgp_status()
     local PGP_NUM_PEERS=$(pgp_jsonrpc \
         '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
         | jq -r '.result')
-    PGP_NUM_PEERS=$(($PGP_NUM_PEERS))
+    PGP_NUM_PEERS=$(hex_to_dec "$PGP_NUM_PEERS")
     if [[ ! "$PGP_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        PGP_NUM_PEERS=0
+        PGP_NUM_PEERS=N/A
     fi
     local PGP_HEIGHT=$(pgp_jsonrpc \
         '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
         | jq -r '.result')
-    PGP_HEIGHT=$(($PGP_HEIGHT))
+    PGP_HEIGHT=$(hex_to_dec "$PGP_HEIGHT")
     if [[ ! "$PGP_HEIGHT" =~ ^[0-9]+$ ]]; then
         PGP_HEIGHT=N/A
     fi
@@ -2727,14 +3852,14 @@ pg_status()
     local PG_NUM_PEERS=$(pg_jsonrpc \
         '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
         | jq -r '.result')
-    PG_NUM_PEERS=$(($PG_NUM_PEERS))
+    PG_NUM_PEERS=$(hex_to_dec "$PG_NUM_PEERS")
     if [[ ! "$PG_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        PG_NUM_PEERS=0
+        PG_NUM_PEERS=N/A
     fi
     local PG_HEIGHT=$(pg_jsonrpc \
         '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
         | jq -r '.result')
-    PG_HEIGHT=$(($PG_HEIGHT))
+    PG_HEIGHT=$(hex_to_dec "$PG_HEIGHT")
     if [[ ! "$PG_HEIGHT" =~ ^[0-9]+$ ]]; then
         PG_HEIGHT=N/A
     fi
@@ -2779,6 +3904,12 @@ esc_remove_log()
 }
 
 
+eco_compress_log()
+{
+    compress_log $SCRIPT_PATH/eco/data/eco/logs/dpos
+    compress_log $SCRIPT_PATH/eco/data/logs-spv
+    compress_log $SCRIPT_PATH/eco/logs
+}
 
 
 pgp_compress_log()
@@ -2795,6 +3926,12 @@ pg_compress_log()
     compress_log $SCRIPT_PATH/pg/logs
 }
 
+eco_remove_log()
+{
+    remove_log $SCRIPT_PATH/eco/data/eco/logs/dpos
+    remove_log $SCRIPT_PATH/eco/data/logs-spv
+    remove_log $SCRIPT_PATH/eco/logs
+}
 
 pgp_remove_log()
 {
@@ -2846,6 +3983,98 @@ esc_update()
     fi
 }
 
+# eco_purge: the ECO side chain is decommissioned network-wide. Stop eco + eco-oracle
+# and DELETE their data - only when ECO actually exists on this node. The eco keystore
+# and its password file are backed up to a tarball first.
+eco_purge()
+{
+    local found= ans ts bk note_tgt=
+    [ -d $SCRIPT_PATH/eco ] && found=1
+    [ -d $SCRIPT_PATH/eco-oracle ] && found=1
+    [ -f ~/.config/elastos/eco.txt ] && found=1
+    pgrep -f '^\./eco .*--rpc ' 1>/dev/null 2>&1 && found=1
+    pgrep -fx 'node crosschain_eco.js' 1>/dev/null 2>&1 && found=1
+    if [ -z "$found" ]; then
+        echo "eco is not installed on this node - nothing to remove."
+        return 0
+    fi
+
+    ui_bold "Remove the decommissioned ECO side chain"; echo
+    echo "  This will stop eco + eco-oracle and DELETE:"
+    [ -d $SCRIPT_PATH/eco ]          && echo "    $SCRIPT_PATH/eco  ($(du -sh $SCRIPT_PATH/eco 2>/dev/null | cut -f1))"
+    [ -d $SCRIPT_PATH/eco-oracle ]   && echo "    $SCRIPT_PATH/eco-oracle"
+    [ -f ~/.config/elastos/eco.txt ] && echo "    ~/.config/elastos/eco.txt"
+    echo "  The eco keystore + password file are backed up first."
+    echo
+    if [ "$1" != "--yes" ] && [ "$1" != "-y" ]; then
+        if noninteractive; then echo_error "refusing to delete unattended - re-run '$SCRIPT_NAME eco purge --yes'"; return 1; fi
+        read -p "Type 'eco' to confirm deletion: " ans
+        [ "$ans" == "eco" ] || { echo "Aborted - nothing changed."; return 1; }
+    fi
+
+    eco_stop 2>/dev/null
+    eco-oracle_stop 2>/dev/null
+
+    ts=$(date '+%F-%H%M%S')
+    bk=~/eco-keystore-backup-$ts.tar.gz
+    if [ -d $SCRIPT_PATH/eco/data/keystore ] || [ -f ~/.config/elastos/eco.txt ]; then
+        if ! tar -czf "$bk" \
+            $( [ -d $SCRIPT_PATH/eco/data/keystore ] && echo "$SCRIPT_PATH/eco/data/keystore" ) \
+            $( [ -f ~/.config/elastos/eco.txt ] && echo "$HOME/.config/elastos/eco.txt" ) 2>/dev/null; then
+            echo_error "keystore backup failed - NOT deleting anything"
+            rm -f "$bk"
+            return 1
+        fi
+        chmod 600 "$bk"
+        echo_ok "keystore backed up: $bk"
+    fi
+
+    # if the data dir was relocated via a symlink, deleting eco/ leaves the target behind
+    if [ -L $SCRIPT_PATH/eco/data ]; then
+        note_tgt=$(readlink "$SCRIPT_PATH/eco/data" 2>/dev/null)
+    fi
+
+    rm -rf $SCRIPT_PATH/eco $SCRIPT_PATH/eco-oracle
+    rm -f ~/.config/elastos/eco.txt
+    echo_ok "eco + eco-oracle removed"
+    [ -n "$note_tgt" ] && echo "  note: eco/data was a symlink to $note_tgt - remove that directory manually to reclaim the space"
+    return 0
+}
+
+eco_update()
+{
+    unset OPTIND
+    while getopts "ny" OPTION; do
+        case $OPTION in
+            n)
+                local NO_START_AFTER_UPDATE=1
+                ;;
+            y)
+                local YES_TO_ALL=1
+                ;;
+        esac
+    done
+
+    chain_prepare_stage eco eco
+    if [ "$?" != "0" ]; then
+        return
+    fi
+
+    local PATH_STAGE=$SCRIPT_PATH/.node-upload/eco
+    local DIR_DEPLOY=$SCRIPT_PATH/eco
+
+    local PID=$(pgrep -f '^\./eco .*--rpc ')
+    if [ $PID ]; then
+        eco_stop
+    fi
+
+    mkdir -p $DIR_DEPLOY
+    cp -v $PATH_STAGE/eco $DIR_DEPLOY/
+
+    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
+        eco_start
+    fi
+}
 
 pgp_update()
 {
@@ -2994,6 +4223,84 @@ esc_init()
 
     touch ${SCRIPT_PATH}/esc/.init
     echo_ok "esc initialized"
+    echo
+}
+eco_init()
+{
+    if [ $(mem_free) -lt 512 ]; then
+        echo_error "free memory not enough"
+        return
+    fi
+
+    local ECO_KEYSTORE=
+    local ECO_KEYSTORE_PASS_FILE=~/.config/elastos/eco.txt
+
+    if [ ! -f ${SCRIPT_PATH}/eco/eco ]; then
+        eco_update -y
+    fi
+
+    if [ -f $SCRIPT_PATH/eco/.init ]; then
+        echo_error "eco has already been initialized"
+        return
+    fi
+
+    cd $SCRIPT_PATH/eco
+    local ECO_NUM_ACCOUNTS=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
+        --nousb --verbosity 0 account list | wc -l)
+    if [ $ECO_NUM_ACCOUNTS -ge 1 ]; then
+        echo_error "eco keystore file exist"
+        return
+    fi
+
+    if [ -f "$ECO_KEYSTORE_PASS_FILE" ]; then
+        echo_error "$ECO_KEYSTORE_PASS_FILE exist"
+        return
+    fi
+
+    echo "Creating eco keystore..."
+    gen_pass
+    if [ "$KEYSTORE_PASS" == "" ]; then
+        echo_error "empty password"
+        exit
+    fi
+
+    echo "Saving eco keystore password..."
+    mkdir -p $(dirname $ECO_KEYSTORE_PASS_FILE)
+    chmod 700 $(dirname $ECO_KEYSTORE_PASS_FILE)
+    echo $KEYSTORE_PASS > $ECO_KEYSTORE_PASS_FILE
+    chmod 600 $ECO_KEYSTORE_PASS_FILE
+
+    cd ${SCRIPT_PATH}/eco
+    ./eco --datadir "$SCRIPT_PATH/eco/data/" --verbosity 0 account new \
+        --password "$ECO_KEYSTORE_PASS_FILE" >/dev/null
+    if [ "$?" != "0" ]; then
+        echo_error "failed to create eco keystore"
+        return
+    fi
+
+    echo "Checking eco keystore..."
+    local ECO_KEYSTORE=$(./eco --datadir "$SCRIPT_PATH/eco/data/" \
+        --nousb --verbosity 0 account list | sed 's/.*keystore:\/\///')
+    chmod 600 $ECO_KEYSTORE
+
+    local ECO_MINER_ADDRESS_FILE=$SCRIPT_PATH/eco/data/miner_address.txt
+    echo "You can input an alternative eco reward address. (ENTER to skip)"
+    local ECO_MINER_ADDRESS=
+    read -p '? Miner Address: ' ECO_MINER_ADDRESS
+    if [ "$ECO_MINER_ADDRESS" != "" ]; then
+        mkdir -p $SCRIPT_PATH/eco/data
+        echo $ECO_MINER_ADDRESS | tee $ECO_MINER_ADDRESS_FILE
+        chmod 600 $ECO_MINER_ADDRESS_FILE
+    fi
+
+    echo_info "eco keystore file: $ECO_KEYSTORE"
+    echo_info "eco keystore password file: $ECO_KEYSTORE_PASS_FILE"
+    if [ -f $ECO_MINER_ADDRESS_FILE ]; then
+        echo_info "eco miner address file: $ECO_MINER_ADDRESS_FILE"
+    fi
+
+    touch ${SCRIPT_PATH}/eco/.init
+    echo_ok "eco initialized"
     echo
 }
 
@@ -3248,9 +4555,46 @@ esc-oracle_start()
         | rotatelogs $SCRIPT_PATH/esc-oracle/logs/esc-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
 
     sleep 1
+    verify_started esc-oracle
     esc-oracle_status
 }
 
+eco-oracle_start()
+{
+    if [ ! -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
+        echo_error "$SCRIPT_PATH/eco-oracle/crosschain_eco.js is not exist"
+        return
+    fi
+
+    local PID=$(pgrep -fx 'node crosschain_eco.js')
+    if [ "$PID" != "" ]; then
+        eco-oracle_status
+        return
+    fi
+
+    echo "Starting eco-oracle..."
+    cd $SCRIPT_PATH/eco-oracle
+    mkdir -p $SCRIPT_PATH/eco-oracle/logs
+
+    if [ "$CHAIN_TYPE" == "mainnet" ]; then
+        export env=mainnet
+    elif [ "$CHAIN_TYPE" == "testnet" ]; then
+        export env=testnet
+    else
+        echo_error "do not support $CHAIN_TYPE"
+        return
+    fi
+
+    echo "env: $env"
+    nodejs_setenv
+    nohup $SHELL -c "node crosschain_eco.js \
+        2>$SCRIPT_PATH/eco-oracle/logs/eco-oracle_err.log \
+        | rotatelogs $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
+
+    sleep 1
+    verify_started eco-oracle
+    eco-oracle_status
+}
 
 pgp-oracle_start()
 {
@@ -3285,6 +4629,7 @@ pgp-oracle_start()
         | rotatelogs $SCRIPT_PATH/pgp-oracle/logs/pgp-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
 
     sleep 1
+    verify_started pgp-oracle
     pgp-oracle_status
 }
 
@@ -3321,6 +4666,7 @@ pg-oracle_start()
         | rotatelogs $SCRIPT_PATH/pg-oracle/logs/pg-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
 
     sleep 1
+    verify_started pg-oracle
     pg-oracle_status
 }
 
@@ -3339,6 +4685,20 @@ esc-oracle_stop()
     esc-oracle_status
 }
 
+eco-oracle_stop()
+{
+    local PID=$(pgrep -fx 'node crosschain_eco.js')
+    if [ "$PID" != "" ]; then
+        echo "Stopping eco-oracle..."
+        kill $PID
+        while ps -p $PID 1>/dev/null; do
+            echo -n .
+            sleep 1
+        done
+        echo
+    fi
+    eco-oracle_status
+}
 
 pgp-oracle_stop()
 {
@@ -3379,6 +4739,14 @@ esc-oracle_installed()
     fi
 }
 
+eco-oracle_installed()
+{
+    if [ -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
+        true
+    else
+        false
+    fi
+}
 
 pgp-oracle_installed()
 {
@@ -3407,6 +4775,14 @@ esc-oracle_ver()
     fi
 }
 
+eco-oracle_ver()
+{
+    if [ -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
+        echo "eco-oracle $(cat $SCRIPT_PATH/eco-oracle/*.js | shasum | cut -c 1-7)"
+    else
+        echo "eco-oracle N/A"
+    fi
+}
 
 pgp-oracle_ver()
 {
@@ -3457,6 +4833,36 @@ esc-oracle_status()
     echo
 }
 
+eco-oracle_status()
+{
+    local ECO_ORACLE_VER=$(eco-oracle_ver)
+
+    local ECO_ORACLE_DISK_USAGE=$(disk_usage $SCRIPT_PATH/eco-oracle)
+
+    local PID=$(pgrep -fx 'node crosschain_eco.js')
+    if [ "$PID" == "" ]; then
+        status_head $ECO_ORACLE_VER Stopped
+        status_info "Disk" "$ECO_ORACLE_DISK_USAGE"
+        echo
+        return
+    fi
+
+    local ECO_ORACLE_RAM=$(mem_usage $PID)
+    local ECO_ORACLE_UPTIME=$(run_time $PID)
+    local ECO_ORACLE_TCP_LISTEN=$(list_tcp $PID)
+    local ECO_ORACLE_NUM_TCPS=$(num_tcps $PID)
+    local ECO_ORACLE_NUM_FILES=$(num_files $PID)
+
+    status_head $ECO_ORACLE_VER Running
+    status_info "Disk"      "$ECO_ORACLE_DISK_USAGE"
+    status_info "PID"       "$PID"
+    status_info "RAM"       "$ECO_ORACLE_RAM"
+    status_info "Uptime"    "$ECO_ORACLE_UPTIME"
+    status_info "#Files"    "$ECO_ORACLE_NUM_FILES"
+    status_info "TCP Ports" "$ECO_ORACLE_TCP_LISTEN"
+    status_info "#TCP"      "$ECO_ORACLE_NUM_TCPS"
+    echo
+}
 
 pgp-oracle_status()
 {
@@ -3530,7 +4936,15 @@ esc-oracle_remove_log()
     remove_log $SCRIPT_PATH/esc-oracle/logs/esc-oracle_out-\*.log
 }
 
+eco-oracle_compress_log()
+{
+    compress_log $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-\*.log
+}
 
+eco-oracle_remove_log()
+{
+    remove_log $SCRIPT_PATH/eco-oracle/logs/eco-oracle_out-\*.log
+}
 
 pgp-oracle_compress_log()
 {
@@ -3547,111 +4961,9 @@ pgp-oracle_remove_log()
     remove_log $SCRIPT_PATH/pgp-oracle/logs/pgp-oracle_out-\*.log
 }
 
-pg-oracle_update()
+pg-oracle_remove_log()
 {
-    unset OPTIND
-    while getopts "ny" OPTION; do
-        case $OPTION in
-            n)
-                local NO_START_AFTER_UPDATE=1
-                ;;
-            y)
-                local YES_TO_ALL=1
-                ;;
-        esac
-    done
-
-    chain_prepare_stage pg-oracle '*.js'
-    if [ "$?" != "0" ]; then
-        return
-    fi
-
-    local PATH_STAGE=$SCRIPT_PATH/.node-upload/pg-oracle
-    local DIR_DEPLOY=$SCRIPT_PATH/pg-oracle
-
-    local PID=$(pgrep -fx 'node crosschain_pg.js')
-    if [ $PID ]; then
-        pg-oracle_stop
-    fi
-
-    mkdir -p $DIR_DEPLOY
-    cp -v $PATH_STAGE/*.js $DIR_DEPLOY/
-
-    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
-        pg-oracle_start
-    fi
-}
-
-esc-oracle_update()
-{
-    unset OPTIND
-    while getopts "ny" OPTION; do
-        case $OPTION in
-            n)
-                local NO_START_AFTER_UPDATE=1
-                ;;
-            y)
-                local YES_TO_ALL=1
-                ;;
-        esac
-    done
-
-    chain_prepare_stage esc-oracle '*.js'
-    if [ "$?" != "0" ]; then
-        return
-    fi
-
-    local PATH_STAGE=$SCRIPT_PATH/.node-upload/esc-oracle
-    local DIR_DEPLOY=$SCRIPT_PATH/esc-oracle
-
-    local PID=$(pgrep -fx 'node crosschain_oracle.js')
-    if [ $PID ]; then
-        esc-oracle_stop
-    fi
-
-    mkdir -p $DIR_DEPLOY
-    cp -v $PATH_STAGE/*.js $DIR_DEPLOY/
-
-    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
-        esc-oracle_start
-    fi
-}
-
-
-
-pgp-oracle_update()
-{
-    unset OPTIND
-    while getopts "ny" OPTION; do
-        case $OPTION in
-            n)
-                local NO_START_AFTER_UPDATE=1
-                ;;
-            y)
-                local YES_TO_ALL=1
-                ;;
-        esac
-    done
-
-    chain_prepare_stage pgp-oracle '*.js'
-    if [ "$?" != "0" ]; then
-        return
-    fi
-
-    local PATH_STAGE=$SCRIPT_PATH/.node-upload/pgp-oracle
-    local DIR_DEPLOY=$SCRIPT_PATH/pgp-oracle
-
-    local PID=$(pgrep -fx 'node crosschain_pgp.js')
-    if [ $PID ]; then
-        pgp-oracle_stop
-    fi
-
-    mkdir -p $DIR_DEPLOY
-    cp -v $PATH_STAGE/*.js $DIR_DEPLOY/
-
-    if [ $PID ] && [ "$NO_START_AFTER_UPDATE" == "" ]; then
-        pgp-oracle_start
-    fi
+    remove_log $SCRIPT_PATH/pg-oracle/logs/pg-oracle_out-\*.log
 }
 
 pg-oracle_update()
@@ -3718,6 +5030,34 @@ esc-oracle_init()
     echo
 }
 
+eco-oracle_init()
+{
+    if [ ! -f ${SCRIPT_PATH}/eco/.init ]; then
+        echo_error "eco not initialized"
+        return
+    fi
+
+    if [ -f $SCRIPT_PATH/eco-oracle/.init ]; then
+        echo_error "eco-oracle has already been initialized"
+        return
+    fi
+
+    check_env_oracle
+
+    if [ ! -f $SCRIPT_PATH/eco-oracle/crosschain_eco.js ]; then
+        eco-oracle_update -y
+    fi
+
+    nodejs_setenv
+
+    mkdir -p $SCRIPT_PATH/eco-oracle
+    cd $SCRIPT_PATH/eco-oracle
+    npm install web3@1.7.3 express@4.18.1
+
+    touch ${SCRIPT_PATH}/eco-oracle/.init
+    echo_ok "eco-oracle initialized"
+    echo
+}
 
 
 pgp-oracle_init()
@@ -3848,12 +5188,12 @@ EOF
     mkdir -p $SCRIPT_PATH/eid/logs/
 
     if [ -f ~/.config/elastos/eid.txt ]; then
+        warn_hot_miner eid
         if [ -f $SCRIPT_PATH/eid/data/miner_address.txt ]; then
             local EID_OPTS="$EID_OPTS --pbft.miner.address $SCRIPT_PATH/eid/data/miner_address.txt"
         fi
         nohup $SHELL -c "./eid \
             $EID_OPTS \
-            --allow-insecure-unlock \
             --datadir $SCRIPT_PATH/eid/data \
             --mine \
             --miner.threads 1 \
@@ -3863,11 +5203,10 @@ EOF
             --pbft.net.address '$(extip)' \
             --pbft.net.port 20649 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'db,eth,miner,net,pbft,personal,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool,pbft' \
             --rpcvhosts '*' \
             --syncmode full \
-            --unlock '0x$(cat $SCRIPT_PATH/eid/data/keystore/UTC* | jq -r .address)' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/eid/logs/eid-%Y-%m-%d-%H_%M_%S.log 20M" &
     else
@@ -3876,14 +5215,15 @@ EOF
             --datadir $SCRIPT_PATH/eid/data \
             --lightserv 10 \
             --rpc \
-            --rpcaddr '0.0.0.0' \
-            --rpcapi 'admin,eth,net,txpool,web3' \
+            --rpcaddr '$(evm_rpc_bind)' \
+            --rpcapi 'eth,net,web3,txpool' \
             --rpcvhosts '*' \
             2>&1 \
             | rotatelogs $SCRIPT_PATH/eid/logs/eid-%Y-%m-%d-%H_%M_%S.log 20M" &
     fi
 
     sleep 3
+    verify_started eid
     eid_status
 }
 
@@ -3998,14 +5338,14 @@ eid_status()
     local EID_NUM_PEERS=$(eid_jsonrpc \
         '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' \
         | jq -r '.result')
-    EID_NUM_PEERS=$(($EID_NUM_PEERS))
+    EID_NUM_PEERS=$(hex_to_dec "$EID_NUM_PEERS")
     if [[ ! "$EID_NUM_PEERS" =~ ^[0-9]+$ ]]; then
-        EID_NUM_PEERS=0
+        EID_NUM_PEERS=N/A
     fi
     local EID_HEIGHT=$(eid_jsonrpc \
         '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
         | jq -r '.result')
-    EID_HEIGHT=$(($EID_HEIGHT))
+    EID_HEIGHT=$(hex_to_dec "$EID_HEIGHT")
     if [[ ! "$EID_HEIGHT" =~ ^[0-9]+$ ]]; then
         EID_HEIGHT=N/A
     fi
@@ -4256,6 +5596,7 @@ eid-oracle_start()
         | rotatelogs $SCRIPT_PATH/eid-oracle/logs/eid-oracle_out-%Y-%m-%d-%H_%M_%S.log 20M" &
 
     sleep 1
+    verify_started eid-oracle
     eid-oracle_status
 }
 
@@ -4443,7 +5784,7 @@ arbiter_start()
         else
             nohup ./arbiter 1>/dev/null 2>output &
         fi
-        echo "Waiting for ela, esc-oracle, eid-oracle to start..."
+        echo "Waiting for ela, esc-oracle, eid-oracle, eco-oracle to start..."
         sleep 5
     done
 
@@ -4571,6 +5912,22 @@ arbiter_status()
         ARBITER_EID_HEIGHT=N/A
     fi
 
+    # linda 添加ECO
+    if [ "$CHAIN_TYPE" == "mainnet" ]; then
+        local ECO_GENESIS=02820c5adc8ee4fb77aad842ac05d95ed8b1041d80c03ba79f8f11c4af60d87c
+    elif [ "$CHAIN_TYPE" == "testnet" ]; then
+        local ECO_GENESIS=3043bcc03c90a37a292a4357ee972bc392b143e75e1b79205e113688e3bd071b
+    else
+        echo_error "do not support $CHAIN_TYPE"
+        return
+    fi
+    local ARBITER_ECO_HEIGHT=$(arbiter_jsonrpc \
+        "{\"method\":\"getsidechainblockheight\",\"params\":{\"hash\":\"$ECO_GENESIS\"}}" \
+        | jq -r '.result')
+    if [[ ! "$ARBITER_ECO_HEIGHT" =~ ^[0-9]+$ ]]; then
+        ARBITER_ECO_HEIGHT=N/A
+    fi
+    # linda 添加
 
     # linda 添加PGP
 
@@ -4620,6 +5977,7 @@ arbiter_status()
     status_info "ESC Height" "$ARBITER_ESC_HEIGHT"
     status_info "EID Height" "$ARBITER_EID_HEIGHT"
     # linda 添加
+    status_info "ECO Height" "$ARBITER_ECO_HEIGHT"
     # linda 添加
     #status_info "PGP Height" "$ARBITER_PGP_HEIGHT"
     # linda 添加
@@ -4792,12 +6150,10 @@ arbiter_init()
         echo_error "eid-oracle not initialized"
         return
     fi
-    #linda添加PG判断
     if [ ! -f $SCRIPT_PATH/pg-oracle/.init ]; then
         echo_error "pg-oracle not initialized"
         return
     fi
-    #linda添加
 
 
     local ELA_CONFIG=${SCRIPT_PATH}/ela/config.json
@@ -4999,29 +6355,75 @@ EOF
     echo
 }
 
-usage()
+# chain_help <chain>: the real per-chain command list (replaces the stale *_usage).
+chain_help()
 {
-    echo "Usage: $SCRIPT_NAME [CHAIN] COMMAND [OPTIONS]"
-    echo "Manage Elastos Node"
+    local chain=$1
+    echo "Usage:  $SCRIPT_NAME $chain <command> [options]"
     echo
-    echo "Diag Info:"
+    echo "  start   stop   restart   status [--json]   health   logs [-f]"
+    echo "  client   rpc   init   update   version"
+    case "$chain" in
+        ela)
+            echo "  send           transfer"
+            echo "  governance:    register-bpos activate-bpos unregister-bpos vote-bpos"
+            echo "                 stake-bpos unstake-bpos claim-bpos register-crc activate-crc unregister-crc"
+            ;;
+        esc|eid|pg)
+            echo "  reward:        set a cold mining address via  $SCRIPT_NAME reward set 0x.."
+            ;;
+        eco)
+            echo "  purge:         stop eco + eco-oracle and DELETE their data (chain is decommissioned)"
+            ;;
+    esac
     echo
-    echo "  Deploy Path:    $SCRIPT_PATH"
-    echo "  Script SHA1:    $SCRIPT_SHA1"
-    echo "  Chains Type:    $CHAIN_TYPE"
-    echo
-    echo "Available Chains:"
-    echo
-    for i in $(grep "^[^ ]\+_ver(" $BASH_SOURCE | sed 's/(.*$//'); do
-    printf "  %-16s%s\n" $(${i})
-    done
-    echo
+    echo "  aliases: up=start   down=stop   rpc=jsonrpc   (kebab-case accepted)"
 }
 
+usage()
+{
+    echo "elastos-node v$ELASTOS_NODE_VERSION - hardened Elastos node runner"
+    echo
+    echo "Usage:  $SCRIPT_NAME <command> [options]"
+    echo "        $SCRIPT_NAME <chain> <command> [options]"
+    echo
+    echo "DAILY"
+    echo "  start | stop       start / stop every chain in the profile"
+    echo "  summary            one row per chain: state, height, peers (add --json)"
+    echo "  status             full status for the profile (--verbose for everything)"
+    echo "  logs [chain] [-f]  tail a chain's log"
+    echo "  health             exit-code health check (0 = all healthy; cron-friendly)"
+    echo
+    echo "SETUP"
+    echo "  setup              prepare a fresh box + initialize (deps, swap, firewall, autostart)"
+    echo "  init               download binaries + create the keystore"
+    echo "  profile [set P]    choose what this node runs (mainchain | full)"
+    echo "  firewall           open peer/consensus ports (RPC stays on 127.0.0.1)"
+    echo "  harden             close public RPC ports + report any restart needed"
+    echo "  reward [set 0x..]  cold miner reward address for the side chains"
+    echo
+    echo "MANAGE"
+    echo "  restart            restart the profile's chains, one at a time (ela needs --force)"
+    echo "  update             update the chain binaries"
+    echo "  migrate            move an upstream install onto this fork (--dry-run | --apply)"
+    echo "  uninstall          stop + remove the install (keystore backed up)"
+    echo "  version | -v       fork + chain versions"
+    echo
+    echo "PER-CHAIN    $SCRIPT_NAME <chain> <command>"
+    echo "  start stop restart status [--json] health logs [-f] client rpc init update version"
+    echo "  run '$SCRIPT_NAME <chain>' for that chain's full list (ela: governance; eco: purge)"
+    echo
+    echo "CHAINS       $(profile_chains 2>/dev/null || echo 'ela esc eid pg + oracles + arbiter')"
+    echo "ALIASES      up=start   down=stop   ps=summary   rpc=jsonrpc   (kebab-case accepted)"
+    echo "MAINTAIN     set_cron   update_script   set_path"
+    echo "FLAGS        --profile <mainchain|full>   --no-color"
+    echo
+    ui_dim "  deploy:$SCRIPT_PATH  sha:$SCRIPT_SHA1  network:$CHAIN_TYPE"; echo
+}
 #
 # Main
 #
-SCRIPT_PATH=$(cd $(dirname $BASH_SOURCE); pwd)
+SCRIPT_PATH=$(cd "$(dirname "$(readlink -f "$BASH_SOURCE" 2>/dev/null || echo "$BASH_SOURCE")")" && pwd)
 SCRIPT_NAME=$(basename $BASH_SOURCE)
 SCRIPT_SHA1=$(shasum $BASH_SOURCE | cut -c1-7)
 
@@ -5029,9 +6431,71 @@ set_env
 check_env
 load_config
 
+# global flag: --profile <mainchain|full> overrides the persisted profile for this run
+PROFILE_OVERRIDE=
+UI_NO_COLOR=
+while true; do
+    case "$1" in
+        --profile)  [ $# -ge 2 ] || { echo_error "--profile needs a value (mainchain|full)"; exit 1; }
+                    PROFILE_OVERRIDE="$2"; shift 2 ;;
+        --no-color) UI_NO_COLOR=1; shift ;;
+        *) break ;;
+    esac
+done
+
+# modern verb aliases -> canonical command (old commands unchanged)
+case "$1" in
+    up)   set -- start "${@:2}" ;;
+    down) set -- stop "${@:2}" ;;
+    ps)   set -- summary "${@:2}" ;;
+esac
+
 # script commands
 if [ "$1" == "" ]; then
     usage
+    exit
+elif [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    usage
+    exit
+elif [ "$1" == "profile" ]; then
+    profile "$2" "$3"
+    exit
+elif [ "$1" == "summary" ]; then
+    if [ "$2" == "--json" ]; then render_json_all; else render_summary; fi
+    exit
+elif [ "$1" == "status" ]; then
+    if [ "$2" == "--verbose" ] || [ "$2" == "-v" ] || [ "$2" == "--all" ]; then all_status; else render_status_all; fi
+    exit
+elif [ "$1" == "health" ]; then
+    render_health_all
+    exit $?
+elif [ "$1" == "restart" ]; then
+    case "$2" in --force|--include-ela) FORCE_ELA=1 ;; esac
+    all_restart
+    exit
+elif [ "$1" == "logs" ]; then
+    logs_cmd "$2" "$3"
+    exit
+elif [ "$1" == "version" ] || [ "$1" == "--version" ] || [ "$1" == "-v" ]; then
+    version_cmd
+    exit
+elif [ "$1" == "reward" ]; then
+    reward_cmd "$2" "$3"
+    exit
+elif [ "$1" == "uninstall" ]; then
+    uninstall_cmd
+    exit
+elif [ "$1" == "migrate" ]; then
+    migrate "$2" "$3"
+    exit $?
+elif [ "$1" == "setup" ]; then
+    setup
+    exit
+elif [ "$1" == "firewall" ]; then
+    firewall
+    exit
+elif [ "$1" == "harden" ]; then
+    harden
     exit
 elif [ "$1" == "set_path" ]; then
     set_path
@@ -5068,27 +6532,48 @@ else
        [ "$1" != "esc-oracle" ] && \
        [ "$1" != "eid"        ] && \
        [ "$1" != "eid-oracle" ] && \
+       [ "$1" != "eco"        ] && \
+       [ "$1" != "eco-oracle" ] && \
        [ "$1" != "pgp"        ] && \
        [ "$1" != "pgp-oracle" ] && \
        [ "$1" != "pg"         ] && \
        [ "$1" != "pg-oracle"  ] && \
        [ "$1" != "arbiter"    ]; then
-        echo_error "do not support chain: $1"
-        exit
+        echo_error "unknown command or chain: $1"
+        echo "  run '$SCRIPT_NAME help' for the full list"
+        did_you_mean "$1" "up down restart ps status summary health logs version setup init start stop update profile firewall reward uninstall ela esc eid pg arbiter"
+        exit 1
     fi
     CHAIN_NAME=$1
     CHAIN_NAME_U=$(echo $CHAIN_NAME | tr "[:lower:]" "[:upper:]")
 
+    # modern per-chain verbs + kebab-case -> canonical command (old commands unchanged)
+    _CMD=$2
+    case "$_CMD" in
+        up)   _CMD=start ;;
+        down) _CMD=stop ;;
+        ps)   _CMD=status ;;
+        rpc)  _CMD=jsonrpc ;;
+    esac
+    _CMD=${_CMD//-/_}
+    if [ -n "$2" ] && [ "$_CMD" != "$2" ]; then set -- "$1" "$_CMD" "${@:3}"; fi
+
     if [ "$2" == "" ]; then
-        # no command specified
-        COMMAND=usage
+        # no command: show this chain's commands and exit non-zero (not a silent success)
+        chain_help "$CHAIN_NAME"
+        exit 1
     elif [ "$2" == "start"   ] || \
          [ "$2" == "stop"    ] || \
          [ "$2" == "status"  ] || \
+         [ "$2" == "health"  ] || \
+         [ "$2" == "restart" ] || \
+         [ "$2" == "logs"    ] || \
+         [ "$2" == "version" ] || \
          [ "$2" == "client"  ] || \
          [ "$2" == "jsonrpc" ] || \
          [ "$2" == "update"  ] || [ "$2" == "upgrade" ] || \
          [ "$2" == "init"    ] || \
+         [ "$2" == "purge"   ] || \
          [ "$2" == "register_bpos"   ] || \
          [ "$2" == "activate_bpos"   ] || \
          [ "$2" == "unregister_bpos" ] || \
@@ -5107,8 +6592,10 @@ else
          [ "$2" == "remove_log"      ]; then
         COMMAND=$2
     else
-        echo_error "do not support command: $2"
-        exit
+        echo_error "unknown command: $2"
+        echo "  run '$SCRIPT_NAME $CHAIN_NAME' to see $CHAIN_NAME commands"
+        did_you_mean "$2" "up down restart start stop status health logs init update client rpc jsonrpc send transfer version register_bpos activate_bpos vote_bpos stake_bpos claim_bpos"
+        exit 1
     fi
     # command aliases
     if [ "$COMMAND" == "upgrade" ]; then
@@ -5116,6 +6603,36 @@ else
     fi
 
     shift 2
+
+    if [ "$COMMAND" == "purge" ] && [ "$CHAIN_NAME" != "eco" ]; then
+        echo_error "purge is only available for the decommissioned eco chain"
+        exit 1
+    fi
+    if [ "$COMMAND" == "status" ]; then
+        case "$1" in
+            --verbose|-v|--all) ${CHAIN_NAME}_status ;;
+            --json)             render_json_one $CHAIN_NAME ;;
+            *)                  render_status_one $CHAIN_NAME ;;
+        esac
+        exit
+    fi
+    if [ "$COMMAND" == "health" ]; then
+        render_health $CHAIN_NAME
+        exit $?
+    fi
+    if [ "$COMMAND" == "restart" ]; then
+        case "$1" in --force|--include-ela) FORCE_ELA=1 ;; esac
+        chain_restart $CHAIN_NAME
+        exit $?
+    fi
+    if [ "$COMMAND" == "logs" ]; then
+        chain_logs $CHAIN_NAME "$@"
+        exit $?
+    fi
+    if [ "$COMMAND" == "version" ]; then
+        "${CHAIN_NAME}_ver" 2>/dev/null || echo_error "no version for $CHAIN_NAME"
+        exit
+    fi
 
     ${CHAIN_NAME}_${COMMAND} "$@"
 fi


### PR DESCRIPTION
## Summary

This proposes the hardened, operator-friendly node.sh runner (distributed as **Elastos Node for Ubuntu**) for the Elastos node tooling. It is **drop-in compatible**: every existing command keeps working, and the directory layout, keystores, binaries, and chain data are unchanged.

It is a large diff because it is a substantial rework. If the maintainers prefer, the security-only subset can be reviewed in isolation.

## Security
- EVM side chains (esc/eid/pg/pgp) bind RPC and WebSocket to `127.0.0.1` (were `0.0.0.0`).
- `--unlock` and `--allow-insecure-unlock` removed; sealing is unaffected (consensus signs with the PBFT keystore).
- `--rpcapi` reduced (drops `personal`, `db`, `admin`, `miner`).
- `dposv2rewardinfo` in `ela_status` is gated behind a sync check so it cannot panic a syncing daemon.
- `harden` closes the host firewall on the RPC/oracle/arbiter ports; `migrate` and `update_script` run it automatically.
- Self-update verifies a published SHA-256 checksum and syntax-checks before installing.

## Operations
- Deployment profiles (`mainchain` or `full`).
- `summary`/`health`/`status`/`logs`, modern verbs, staged `migrate`, `eco purge`, one-line `install.sh`.
- `update_script` and `install.sh` point at `elastos/Elastos.Node`.

## Compatibility
- All existing commands keep working; no data migration or resync.
- Local tooling reaches the RPC over loopback, unaffected.

## Reverting
Revert this commit to restore the previous `build/skeleton/node.sh`.
