### PR TITLE
docs: sync repo guides with the init-only setup model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented in this file. Releases are tagged `vMAJOR.MINOR.PATCH`.
 
+## Unreleased
+
+### Changed
+- **`setup` is now init-only.** It initializes the chains and no longer installs packages or touches the firewall. Install dependencies manually (`check_env` reports the exact `apt-get` line for any that are missing). Opening the peer/consensus ports is a separate, SSH-safe `firewall` command that detects the real SSH port (`sshd -T` and `$SSH_CONNECTION`) and asks before enabling `ufw`, so a node on a non-standard SSH port is never locked out. Swap headroom and autostart are the dedicated `swap` and `set_cron` commands.
+
+### Added
+- **`swap`** command — adds 16 GB of swap headroom, and recovers a leftover inactive `/swapfile` instead of skipping it.
+
+### Fixed
+- **`stop` no longer hangs** if a chain ignores `SIGTERM`: a bounded wait, then `SIGKILL` escalation.
+- **`init` is resumable** for `ela`/`esc`/`eid`/`pg`: an interrupted init that created the keystore but not the `.init` marker is adopted (the keystore is never overwritten) instead of bailing.
+- **`check_env`** reports every missing tool at once and exits non-zero.
+- `install.sh` fails closed if the published checksum cannot be fetched.
+- The arbiter startup message no longer references the decommissioned `eco-oracle`.
+- `node.sh` uses `sha256sum` (always present on Ubuntu) instead of `shasum`.
+
 ## v1.1.0 - First stable release
 
 Validated end to end on a live node: one-line migration, the read views, the per-chain hardening restart (rebinding RPC to `127.0.0.1` with `--unlock` and `personal` removed), the firewall hardening, and ECO removal. This release consolidates the `1.0.0-rc` series into a stable tag.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -35,9 +35,9 @@ Elastos Node for Ubuntu keeps the original data layout, binaries, daemons, and c
 
 | Area | Earlier Elastos.Node runner | Elastos Node for Ubuntu |
 |---|---|---|
-| Installation | Manual steps from the documentation: dependencies, swap, firewall, cron, then per-chain `init` | `setup`: one command for dependencies, swap, firewall, autostart, and `init` |
+| Installation | Manual steps from the documentation: dependencies, swap, firewall, cron, then per-chain `init` | Checksum-verified one-line installer; `setup` initializes the chains; `swap`, `firewall` (detects your SSH port and confirms before enabling), and `set_cron` are dedicated commands |
 | Deployment shape | Full stack only | `mainchain` and `full` profiles; `--profile` override per command |
-| Command style | `./node.sh <chain> <command>` | Unchanged, plus `up`, `down`, `restart`, `ps`, `logs [-f]`, `version`, `rpc`, and a global `node.sh` wrapper |
+| Command style | `./node.sh <chain> <command>` | Unchanged, plus `up`, `down`, `restart`, `ps`, `logs [-f]`, `version`, and `rpc` |
 | Fleet overview | Per-chain status blocks only | `summary` (one row per chain) and `health` (verdict with exit code) |
 | Machine output | None | `--json` on `summary` and `status`; `--no-color` and `NO_COLOR` support |
 | Log access | Locate the rotated log file manually | `logs [<chain>] [-f]` selects the most recent log |

--- a/docs/bpos-setup.md
+++ b/docs/bpos-setup.md
@@ -17,10 +17,11 @@ After registering the BPoS node with Essentials, complete the BPoS node build wi
 
 ### ELA node setup
 
-1. Install `node.sh` with the one-liner. On a fresh host follow it with `node.sh setup` (dependencies, swap, firewall, autostart, then init):
+1. Install `node.sh` with the one-liner, then install the dependencies it needs:
 
    ```bash
    $ curl -fsSL https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/install.sh | bash
+   $ sudo apt-get install -y jq lsof apache2-utils curl openssl
    ```
 
 2. Select the `mainchain` profile so only the ELA node is installed and managed:
@@ -29,10 +30,11 @@ After registering the BPoS node with Essentials, complete the BPoS node build wi
    $ ~/node/node.sh profile set mainchain
    ```
 
-3. Initialize and start the node, then bind the nodepublickey using Essentials:
+3. Initialize the node, open the peer/consensus ports, and start it, then bind the nodepublickey using Essentials:
 
    ```bash
    $ ~/node/node.sh init
+   $ ~/node/node.sh firewall
    $ ~/node/node.sh start
    ```
 

--- a/docs/crc-setup.md
+++ b/docs/crc-setup.md
@@ -16,10 +16,11 @@ After registering the CRC node with Essentials, complete the CRC node build with
 
 ### ELA node setup
 
-1. Install `node.sh` with the one-liner, then run `node.sh setup` on a fresh host (dependencies, swap, firewall, autostart, then init):
+1. Install `node.sh` with the one-liner and the dependencies, then run `node.sh setup` on a fresh host:
 
    ```bash
    $ curl -fsSL https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/install.sh | bash
+   $ sudo apt-get install -y jq lsof apache2-utils curl openssl
    $ ~/node/node.sh setup
    ```
 
@@ -29,11 +30,12 @@ After registering the CRC node with Essentials, complete the CRC node build with
    $ ~/node/node.sh profile set full
    ```
 
-   This installs all programs in one pass: ELA, ESC, EID, PG, the ESC/EID/PG oracles, and the arbiter. View more sample [programs](archives/step-by-step-setup/installing-programs).
+   This initializes all chains in one pass: ELA, ESC, EID, PG, the ESC/EID/PG oracles, and the arbiter. View more sample [programs](archives/step-by-step-setup/installing-programs).
 
-2. Start the node and bind the nodepublickey using Essentials:
+2. Open the peer/consensus ports, start the node, and bind the nodepublickey using Essentials:
 
    ```bash
+   $ ~/node/node.sh firewall
    $ ~/node/node.sh start
    ```
 

--- a/docs/quick-setup.md
+++ b/docs/quick-setup.md
@@ -8,10 +8,12 @@ The fastest path runs the installer. It downloads `node.sh`, verifies the publis
 $ curl -fsSL https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/install.sh | bash
 ```
 
-On a fresh host this installs `node.sh` and points you to `node.sh setup`, which is the turnkey path: it installs dependencies, adds swap, configures the firewall, enables autostart, and then runs `init`.
+On a fresh host this installs `node.sh` and prints the next steps. Install the dependencies, then `node.sh setup` initializes the chains; open the peer/consensus ports separately with `node.sh firewall`, which detects your SSH port and asks before enabling:
 
 ```bash
+$ sudo apt-get install -y jq lsof apache2-utils curl openssl
 $ ~/node/node.sh setup
+$ ~/node/node.sh firewall
 ```
 
 To place the script by hand instead, download it and make it executable:

--- a/docs/what-is-node.sh.md
+++ b/docs/what-is-node.sh.md
@@ -24,7 +24,7 @@ The fastest way to install it on a fresh host is the one-liner, which also migra
 curl -fsSL https://raw.githubusercontent.com/elastos/Elastos.Node/master/build/skeleton/install.sh | bash
 ```
 
-Then run `node.sh setup` for a turnkey host preparation (dependencies, swap, firewall, autostart, then init).
+Install the dependencies, then run `node.sh setup` to initialize the chains. Opening the peer/consensus ports is a separate, SSH-safe step (`node.sh firewall`).
 
 node.sh supports:
 


### PR DESCRIPTION
The repo docs lagged the merged node.sh behavior. quick-setup, bpos-setup, crc-setup, what-is-node.sh, and COMPARISON.md still described `setup` as the all-in-one ("dependencies, swap, firewall, autostart, then init"), and COMPARISON listed the removed global `node.sh` wrapper.

- Install flows updated to: install deps -> `node.sh setup` (initializes the chains) -> `node.sh firewall` (SSH-safe) -> `node.sh start`.
- COMPARISON: `setup` row corrected; removed the dropped global wrapper.
- Added an `Unreleased` CHANGELOG entry for the init-only restructure + the stop/resumable-init/swap/arbiter fixes.

(SECURITY.md was already accurate; the docs.elastos.net portal and the README were already updated. CHANGELOG entries for past releases are historical and left as-is.)